### PR TITLE
Fix registro visit submission

### DIFF
--- a/app/src/main/java/com/example/bitacoradigital/ui/screens/registrovisita/PasoConfirmacion.kt
+++ b/app/src/main/java/com/example/bitacoradigital/ui/screens/registrovisita/PasoConfirmacion.kt
@@ -50,7 +50,7 @@ fun PasoConfirmacion(viewModel: RegistroVisitaViewModel) {
                 Text("👤 Nombre: $nombre $paterno $materno")
                 destino?.let {
                     Spacer(Modifier.height(4.dp))
-                    Text("📍 Destino: Perímetro ID $it") // Puedes mejorar esto con una función de nombre si lo tienes
+                    Text("📍 Destino: ${it.nombre} (ID ${it.perimetro_id})")
                 }
             }
         }
@@ -91,7 +91,7 @@ fun PasoConfirmacion(viewModel: RegistroVisitaViewModel) {
 
         Button(
             onClick = {
-                viewModel.registroCompleto.value = true // futuro: mandar a endpoint
+                viewModel.registrarVisita()
                 viewModel.avanzarPaso()
             },
             modifier = Modifier.fillMaxWidth()

--- a/app/src/main/java/com/example/bitacoradigital/viewmodel/RegistroVisitaViewModel.kt
+++ b/app/src/main/java/com/example/bitacoradigital/viewmodel/RegistroVisitaViewModel.kt
@@ -134,7 +134,7 @@ class RegistroVisitaViewModel(
             try {
                 val token = sessionPrefs.sessionToken.first() ?: throw Exception("Token vacío")
 
-                val zonaId = obtenerDestinoFinal()?.perimetroId
+                val zonaId = destinoSeleccionado.value?.perimetro_id
                     ?: throw Exception("Zona destino no seleccionada")
 
                 val dateFormat = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'", Locale.US).apply {


### PR DESCRIPTION
## Summary
- ensure selected perimetro id is used when submitting visita
- show selected destination name
- trigger visit registration from confirmation step

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_684887e1221c832f9c41252de0a969ac