### PR TITLE
Implement signup and email verification

### DIFF
--- a/app/src/main/java/com/example/bitacoradigital/model/SignupRequest.kt
+++ b/app/src/main/java/com/example/bitacoradigital/model/SignupRequest.kt
@@ -1,0 +1,10 @@
+package com.example.bitacoradigital.model
+
+data class SignupRequest(
+    val email: String,
+    val password: String,
+    val nombre: String,
+    val apellidoPaterno: String,
+    val apellidoMaterno: String,
+    val nombreInstancia: String
+)

--- a/app/src/main/java/com/example/bitacoradigital/model/SignupResponse.kt
+++ b/app/src/main/java/com/example/bitacoradigital/model/SignupResponse.kt
@@ -1,0 +1,21 @@
+package com.example.bitacoradigital.model
+
+data class SignupResponse(
+    val status: Int,
+    val data: SignupData,
+    val meta: SignupMeta
+)
+
+data class SignupData(
+    val flows: List<SignupFlow>
+)
+
+data class SignupFlow(
+    val id: String,
+    val is_pending: Boolean? = null
+)
+
+data class SignupMeta(
+    val is_authenticated: Boolean,
+    val session_token: String
+)

--- a/app/src/main/java/com/example/bitacoradigital/model/VerifyEmailRequest.kt
+++ b/app/src/main/java/com/example/bitacoradigital/model/VerifyEmailRequest.kt
@@ -1,0 +1,5 @@
+package com.example.bitacoradigital.model
+
+data class VerifyEmailRequest(
+    val key: String
+)

--- a/app/src/main/java/com/example/bitacoradigital/navigation/NavGraph.kt
+++ b/app/src/main/java/com/example/bitacoradigital/navigation/NavGraph.kt
@@ -11,6 +11,8 @@ import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
 import com.example.bitacoradigital.ui.screens.auth.LoginScreen
+import com.example.bitacoradigital.ui.screens.auth.SignupScreen
+import com.example.bitacoradigital.ui.screens.auth.VerificationScreen
 import androidx.navigation.compose.composable
 import com.example.bitacoradigital.data.SessionPreferences
 import com.example.bitacoradigital.network.ApiService
@@ -18,6 +20,7 @@ import com.example.bitacoradigital.ui.screens.*
 import com.example.bitacoradigital.viewmodel.HomeViewModel
 import com.example.bitacoradigital.viewmodel.LoginViewModel
 import com.example.bitacoradigital.viewmodel.SessionViewModel
+import com.example.bitacoradigital.viewmodel.SignupViewModel
 
 
 @Composable
@@ -43,6 +46,8 @@ fun AppNavGraph(
     }
 
 
+    val signupViewModel: SignupViewModel = viewModel()
+
     NavHost(navController = navController, startDestination = startDestination) {
 
         composable("login") {
@@ -52,7 +57,27 @@ fun AppNavGraph(
                 homeViewModel = homeViewModel, // ⬅️ IMPORTANTE
                 onLoginSuccess = { navController.navigate("home") { popUpTo("login") { inclusive = true } } },
                 onLoginDenied = { navController.navigate("denegado") { popUpTo("login") { inclusive = true } } },
-                onRegisterClick = { /* pendiente */ }
+                onRegisterClick = { navController.navigate("register") }
+            )
+        }
+
+        composable("register") {
+            SignupScreen(
+                signupViewModel = signupViewModel,
+                sessionViewModel = sessionViewModel,
+                onAwaitCode = { navController.navigate("verify") },
+                onLoginClick = { navController.popBackStack() }
+            )
+        }
+
+        composable("verify") {
+            VerificationScreen(
+                signupViewModel = signupViewModel,
+                sessionViewModel = sessionViewModel,
+                homeViewModel = homeViewModel,
+                onVerified = {
+                    navController.navigate("home") { popUpTo("login") { inclusive = true } }
+                }
             )
         }
         composable("visitas") {

--- a/app/src/main/java/com/example/bitacoradigital/network/AuthApi.kt
+++ b/app/src/main/java/com/example/bitacoradigital/network/AuthApi.kt
@@ -2,11 +2,24 @@ package com.example.bitacoradigital.network
 
 import com.example.bitacoradigital.model.LoginRequest
 import com.example.bitacoradigital.model.LoginResponse
+import com.example.bitacoradigital.model.SignupRequest
+import com.example.bitacoradigital.model.SignupResponse
+import com.example.bitacoradigital.model.VerifyEmailRequest
+import retrofit2.http.Header
 import retrofit2.http.Body
 import retrofit2.http.POST
 
 interface AuthApi {
     @POST("_allauth/app/v1/auth/login")
     suspend fun login(@Body request: LoginRequest): LoginResponse
+
+    @POST("_allauth/app/v1/auth/signup")
+    suspend fun signup(@Body request: SignupRequest): SignupResponse
+
+    @POST("_allauth/app/v1/auth/email/verify")
+    suspend fun verifyEmail(
+        @Header("x-session-token") token: String,
+        @Body request: VerifyEmailRequest
+    ): LoginResponse
 
 }

--- a/app/src/main/java/com/example/bitacoradigital/ui/screens/auth/SignupScreen.kt
+++ b/app/src/main/java/com/example/bitacoradigital/ui/screens/auth/SignupScreen.kt
@@ -1,0 +1,140 @@
+package com.example.bitacoradigital.ui.screens.auth
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.PersonAdd
+import androidx.compose.material.icons.filled.Visibility
+import androidx.compose.material.icons.filled.VisibilityOff
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.text.input.PasswordVisualTransformation
+import androidx.compose.ui.text.input.VisualTransformation
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.example.bitacoradigital.model.SignupRequest
+import com.example.bitacoradigital.viewmodel.SessionViewModel
+import com.example.bitacoradigital.viewmodel.SignupViewModel
+
+@Composable
+fun SignupScreen(
+    signupViewModel: SignupViewModel,
+    sessionViewModel: SessionViewModel,
+    onAwaitCode: () -> Unit,
+    onLoginClick: () -> Unit
+) {
+    var email by remember { mutableStateOf("") }
+    var password by remember { mutableStateOf("") }
+    var nombre by remember { mutableStateOf("") }
+    var apellidoPaterno by remember { mutableStateOf("") }
+    var apellidoMaterno by remember { mutableStateOf("") }
+    var instancia by remember { mutableStateOf("") }
+    var showPassword by remember { mutableStateOf(false) }
+    val state = signupViewModel.signupState
+
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(horizontal = 32.dp),
+        verticalArrangement = Arrangement.Center,
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Text("Registro", style = MaterialTheme.typography.headlineSmall)
+        Spacer(modifier = Modifier.height(24.dp))
+
+        OutlinedTextField(
+            value = email,
+            onValueChange = { email = it },
+            label = { Text("Correo electrónico") },
+            singleLine = true,
+            keyboardOptions = KeyboardOptions.Default.copy(keyboardType = KeyboardType.Email),
+            modifier = Modifier.fillMaxWidth()
+        )
+
+        OutlinedTextField(
+            value = password,
+            onValueChange = { password = it },
+            label = { Text("Contraseña") },
+            singleLine = true,
+            visualTransformation = if (showPassword) VisualTransformation.None else PasswordVisualTransformation(),
+            trailingIcon = {
+                IconButton(onClick = { showPassword = !showPassword }) {
+                    Icon(imageVector = if (showPassword) Icons.Default.VisibilityOff else Icons.Default.Visibility, contentDescription = "Mostrar contraseña")
+                }
+            },
+            keyboardOptions = KeyboardOptions.Default.copy(keyboardType = KeyboardType.Password),
+            modifier = Modifier.fillMaxWidth()
+        )
+
+        OutlinedTextField(
+            value = nombre,
+            onValueChange = { nombre = it },
+            label = { Text("Nombre") },
+            singleLine = true,
+            modifier = Modifier.fillMaxWidth()
+        )
+
+        OutlinedTextField(
+            value = apellidoPaterno,
+            onValueChange = { apellidoPaterno = it },
+            label = { Text("Apellido Paterno") },
+            singleLine = true,
+            modifier = Modifier.fillMaxWidth()
+        )
+
+        OutlinedTextField(
+            value = apellidoMaterno,
+            onValueChange = { apellidoMaterno = it },
+            label = { Text("Apellido Materno") },
+            singleLine = true,
+            modifier = Modifier.fillMaxWidth()
+        )
+
+        OutlinedTextField(
+            value = instancia,
+            onValueChange = { instancia = it },
+            label = { Text("Nombre de Instancia") },
+            singleLine = true,
+            modifier = Modifier.fillMaxWidth()
+        )
+
+        Spacer(modifier = Modifier.height(16.dp))
+
+        Button(
+            onClick = {
+                val req = SignupRequest(
+                    email = email,
+                    password = password,
+                    nombre = nombre,
+                    apellidoPaterno = apellidoPaterno,
+                    apellidoMaterno = apellidoMaterno,
+                    nombreInstancia = instancia
+                )
+                signupViewModel.signup(req, sessionViewModel, onAwaitCode)
+            },
+            modifier = Modifier.fillMaxWidth(),
+            colors = ButtonDefaults.buttonColors(containerColor = MaterialTheme.colorScheme.secondary)
+        ) {
+            Icon(Icons.Default.PersonAdd, contentDescription = null)
+            Spacer(Modifier.width(8.dp))
+            Text("Registrarse")
+        }
+
+        state?.let {
+            Spacer(Modifier.height(8.dp))
+            Text(it, color = MaterialTheme.colorScheme.error)
+        }
+
+        Spacer(modifier = Modifier.height(8.dp))
+        Text(
+            text = "¿Ya tienes cuenta? Inicia sesión",
+            modifier = Modifier.clickable { onLoginClick() }.padding(4.dp),
+            color = MaterialTheme.colorScheme.primary,
+            fontSize = 14.sp
+        )
+    }
+}

--- a/app/src/main/java/com/example/bitacoradigital/ui/screens/auth/VerificationScreen.kt
+++ b/app/src/main/java/com/example/bitacoradigital/ui/screens/auth/VerificationScreen.kt
@@ -1,0 +1,58 @@
+package com.example.bitacoradigital.ui.screens.auth
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.input.KeyboardOptions
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.unit.dp
+import com.example.bitacoradigital.viewmodel.HomeViewModel
+import com.example.bitacoradigital.viewmodel.SessionViewModel
+import com.example.bitacoradigital.viewmodel.SignupViewModel
+
+@Composable
+fun VerificationScreen(
+    signupViewModel: SignupViewModel,
+    sessionViewModel: SessionViewModel,
+    homeViewModel: HomeViewModel,
+    onVerified: () -> Unit
+) {
+    var code by remember { mutableStateOf("") }
+    val state = signupViewModel.signupState
+
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(32.dp),
+        verticalArrangement = Arrangement.Center,
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Text("Verifica tu correo", style = MaterialTheme.typography.headlineSmall)
+        Spacer(Modifier.height(16.dp))
+
+        OutlinedTextField(
+            value = code,
+            onValueChange = { code = it },
+            label = { Text("Código de verificación") },
+            keyboardOptions = KeyboardOptions.Default.copy(keyboardType = KeyboardType.Number),
+            singleLine = true,
+            modifier = Modifier.fillMaxWidth()
+        )
+
+        Spacer(modifier = Modifier.height(16.dp))
+
+        Button(
+            onClick = { signupViewModel.verifyEmail(code, sessionViewModel, homeViewModel, onVerified) },
+            modifier = Modifier.fillMaxWidth()
+        ) {
+            Text("Verificar")
+        }
+
+        state?.let {
+            Spacer(modifier = Modifier.height(8.dp))
+            Text(it, color = MaterialTheme.colorScheme.error)
+        }
+    }
+}

--- a/app/src/main/java/com/example/bitacoradigital/viewmodel/SessionViewModel.kt
+++ b/app/src/main/java/com/example/bitacoradigital/viewmodel/SessionViewModel.kt
@@ -68,6 +68,10 @@ class SessionViewModel(application: Application) : AndroidViewModel(application)
         prefs.guardarSesion(token, user.id, gson.toJson(user))
     }
 
+    fun setTemporalToken(token: String) {
+        _token.value = token
+    }
+
     suspend fun cerrarSesion() {
         prefs.cerrarSesion()
         _token.value = null

--- a/app/src/main/java/com/example/bitacoradigital/viewmodel/SignupViewModel.kt
+++ b/app/src/main/java/com/example/bitacoradigital/viewmodel/SignupViewModel.kt
@@ -1,0 +1,53 @@
+package com.example.bitacoradigital.viewmodel
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.setValue
+import com.example.bitacoradigital.model.SignupRequest
+import com.example.bitacoradigital.model.VerifyEmailRequest
+import com.example.bitacoradigital.network.RetrofitInstance
+import kotlinx.coroutines.launch
+
+class SignupViewModel : ViewModel() {
+    var signupState by mutableStateOf<String?>(null)
+        private set
+
+    fun signup(
+        request: SignupRequest,
+        sessionViewModel: SessionViewModel,
+        onAwaitCode: () -> Unit
+    ) {
+        viewModelScope.launch {
+            try {
+                val response = RetrofitInstance.authApi.signup(request)
+                sessionViewModel.setTemporalToken(response.meta.session_token)
+                signupState = null
+                onAwaitCode()
+            } catch (e: Exception) {
+                signupState = "Error: ${e.localizedMessage}"
+            }
+        }
+    }
+
+    fun verifyEmail(
+        code: String,
+        sessionViewModel: SessionViewModel,
+        homeViewModel: HomeViewModel,
+        onSuccess: () -> Unit
+    ) {
+        viewModelScope.launch {
+            try {
+                val token = sessionViewModel.token.value ?: return@launch
+                val response = RetrofitInstance.authApi.verifyEmail(token, VerifyEmailRequest(code))
+                sessionViewModel.guardarSesion(response.meta.session_token, response.data.user)
+                homeViewModel.cargarDesdeLogin(response.data.user, sessionViewModel)
+                signupState = null
+                onSuccess()
+            } catch (e: Exception) {
+                signupState = "Error: ${e.localizedMessage}"
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- implement signup API models
- add AuthApi calls for signup and verification
- create SignupViewModel
- add SignupScreen and VerificationScreen compose UIs
- update navigation and session handling for signup flows

## Testing
- `./gradlew test --dry-run` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_684891c2cf70832fac042e423eb1a2e4