### PR TITLE
Implement login email verification flow

### DIFF
--- a/app/src/main/java/com/example/bitacoradigital/navigation/NavGraph.kt
+++ b/app/src/main/java/com/example/bitacoradigital/navigation/NavGraph.kt
@@ -57,6 +57,7 @@ fun AppNavGraph(
                 homeViewModel = homeViewModel, // ⬅️ IMPORTANTE
                 onLoginSuccess = { navController.navigate("home") { popUpTo("login") { inclusive = true } } },
                 onLoginDenied = { navController.navigate("denegado") { popUpTo("login") { inclusive = true } } },
+                onAwaitCode = { navController.navigate("verify") },
                 onRegisterClick = { navController.navigate("register") }
             )
         }

--- a/app/src/main/java/com/example/bitacoradigital/ui/screens/auth/LoginScreen.kt
+++ b/app/src/main/java/com/example/bitacoradigital/ui/screens/auth/LoginScreen.kt
@@ -25,6 +25,7 @@ fun LoginScreen(
     homeViewModel: HomeViewModel, // ← NUEVO
     onLoginSuccess: () -> Unit,
     onLoginDenied: () -> Unit,
+    onAwaitCode: () -> Unit = {},
     onRegisterClick: () -> Unit,
     onForgotPasswordClick: () -> Unit = {}
 )
@@ -93,7 +94,8 @@ fun LoginScreen(
                         }
                         onLoginSuccess()
                     },
-                    onLoginDenied = onLoginDenied
+                    onLoginDenied = onLoginDenied,
+                    onAwaitCode = onAwaitCode
                 )
             },
             modifier = Modifier.fillMaxWidth()

--- a/app/src/main/java/com/example/bitacoradigital/viewmodel/LoginViewModel.kt
+++ b/app/src/main/java/com/example/bitacoradigital/viewmodel/LoginViewModel.kt
@@ -4,6 +4,9 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.example.bitacoradigital.model.LoginRequest
 import com.example.bitacoradigital.network.RetrofitInstance
+import com.example.bitacoradigital.model.SignupResponse
+import com.google.gson.Gson
+import retrofit2.HttpException
 import kotlinx.coroutines.launch
 import androidx.compose.runtime.*
 
@@ -17,7 +20,8 @@ class LoginViewModel : ViewModel() {
         password: String,
         sessionViewModel: SessionViewModel,
         onLoginSuccess: () -> Unit,
-        onLoginDenied: () -> Unit
+        onLoginDenied: () -> Unit,
+        onAwaitCode: () -> Unit
     ) {
         viewModelScope.launch {
             try {
@@ -34,6 +38,21 @@ class LoginViewModel : ViewModel() {
                     onLoginDenied()
                 }
 
+            } catch (e: HttpException) {
+                if (e.code() == 401) {
+                    val json = e.response()?.errorBody()?.string()
+                    val body = json?.let { Gson().fromJson(it, SignupResponse::class.java) }
+                    val token = body?.meta?.session_token
+                    if (token != null) {
+                        sessionViewModel.setTemporalToken(token)
+                        loginState = null
+                        onAwaitCode()
+                    } else {
+                        loginState = "Cuenta no verificada"
+                    }
+                } else {
+                    loginState = "Error: ${e.localizedMessage}"
+                }
             } catch (e: Exception) {
                 loginState = "Error: ${e.localizedMessage}"
             }


### PR DESCRIPTION
## Summary
- handle 401 login responses by storing session token and showing the verification screen
- allow `LoginScreen` to request verification code when required
- update navigation to support verification after login

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848c23a3b50832f93f22d554d8a02dc