### PR TITLE
Implementar flujo de recuperación de contraseña

### DIFF
--- a/app/src/main/java/com/example/bitacoradigital/MainActivity.kt
+++ b/app/src/main/java/com/example/bitacoradigital/MainActivity.kt
@@ -11,6 +11,7 @@ import com.example.bitacoradigital.ui.theme.BitacoraDigitalTheme
 import com.example.bitacoradigital.viewmodel.HomeViewModel
 import com.example.bitacoradigital.viewmodel.LoginViewModel
 import com.example.bitacoradigital.viewmodel.SessionViewModel
+import com.example.bitacoradigital.viewmodel.ForgotPasswordViewModel
 
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -25,12 +26,14 @@ class MainActivity : ComponentActivity() {
                     val loginViewModel: LoginViewModel = viewModel()
                     val sessionViewModel: SessionViewModel = viewModel(factory = SessionViewModel.Factory(applicationContext))
                     val homeViewModel: HomeViewModel = viewModel()
+                    val forgotPasswordViewModel: ForgotPasswordViewModel = viewModel()
 
                     AppNavGraph(
                         navController = navController,
                         loginViewModel = loginViewModel,
                         sessionViewModel = sessionViewModel,
-                        homeViewModel = homeViewModel
+                        homeViewModel = homeViewModel,
+                        forgotPasswordViewModel = forgotPasswordViewModel
                     )
                 }
             }

--- a/app/src/main/java/com/example/bitacoradigital/model/PasswordRequest.kt
+++ b/app/src/main/java/com/example/bitacoradigital/model/PasswordRequest.kt
@@ -1,0 +1,5 @@
+package com.example.bitacoradigital.model
+
+data class PasswordRequest(
+    val email: String
+)

--- a/app/src/main/java/com/example/bitacoradigital/model/PasswordResetRequest.kt
+++ b/app/src/main/java/com/example/bitacoradigital/model/PasswordResetRequest.kt
@@ -1,0 +1,6 @@
+package com.example.bitacoradigital.model
+
+data class PasswordResetRequest(
+    val key: String,
+    val password: String
+)

--- a/app/src/main/java/com/example/bitacoradigital/navigation/NavGraph.kt
+++ b/app/src/main/java/com/example/bitacoradigital/navigation/NavGraph.kt
@@ -13,6 +13,8 @@ import androidx.navigation.compose.NavHost
 import com.example.bitacoradigital.ui.screens.auth.LoginScreen
 import com.example.bitacoradigital.ui.screens.auth.SignupScreen
 import com.example.bitacoradigital.ui.screens.auth.VerificationScreen
+import com.example.bitacoradigital.ui.screens.auth.PasswordRequestScreen
+import com.example.bitacoradigital.ui.screens.auth.PasswordResetScreen
 import androidx.navigation.compose.composable
 import com.example.bitacoradigital.data.SessionPreferences
 import com.example.bitacoradigital.network.ApiService
@@ -21,6 +23,7 @@ import com.example.bitacoradigital.viewmodel.HomeViewModel
 import com.example.bitacoradigital.viewmodel.LoginViewModel
 import com.example.bitacoradigital.viewmodel.SessionViewModel
 import com.example.bitacoradigital.viewmodel.SignupViewModel
+import com.example.bitacoradigital.viewmodel.ForgotPasswordViewModel
 
 
 @Composable
@@ -28,7 +31,8 @@ fun AppNavGraph(
     navController: NavHostController,
     loginViewModel: LoginViewModel,
     sessionViewModel: SessionViewModel,
-    homeViewModel: HomeViewModel
+    homeViewModel: HomeViewModel,
+    forgotPasswordViewModel: ForgotPasswordViewModel
 ) {
     val usuario by sessionViewModel.usuario.collectAsState()
     LaunchedEffect(usuario) {
@@ -47,6 +51,7 @@ fun AppNavGraph(
 
 
     val signupViewModel: SignupViewModel = viewModel()
+    val forgotPasswordViewModel: ForgotPasswordViewModel = viewModel()
 
     NavHost(navController = navController, startDestination = startDestination) {
 
@@ -58,7 +63,8 @@ fun AppNavGraph(
                 onLoginSuccess = { navController.navigate("home") { popUpTo("login") { inclusive = true } } },
                 onLoginDenied = { navController.navigate("denegado") { popUpTo("login") { inclusive = true } } },
                 onAwaitCode = { navController.navigate("verify") },
-                onRegisterClick = { navController.navigate("register") }
+                onRegisterClick = { navController.navigate("register") },
+                onForgotPasswordClick = { navController.navigate("forgot/email") }
             )
         }
 
@@ -77,6 +83,25 @@ fun AppNavGraph(
                 sessionViewModel = sessionViewModel,
                 homeViewModel = homeViewModel,
                 onVerified = {
+                    navController.navigate("home") { popUpTo("login") { inclusive = true } }
+                }
+            )
+        }
+
+        composable("forgot/email") {
+            PasswordRequestScreen(
+                viewModel = forgotPasswordViewModel,
+                sessionViewModel = sessionViewModel,
+                onAwaitCode = { navController.navigate("forgot/reset") }
+            )
+        }
+
+        composable("forgot/reset") {
+            PasswordResetScreen(
+                viewModel = forgotPasswordViewModel,
+                sessionViewModel = sessionViewModel,
+                homeViewModel = homeViewModel,
+                onSuccess = {
                     navController.navigate("home") { popUpTo("login") { inclusive = true } }
                 }
             )

--- a/app/src/main/java/com/example/bitacoradigital/network/AuthApi.kt
+++ b/app/src/main/java/com/example/bitacoradigital/network/AuthApi.kt
@@ -5,6 +5,8 @@ import com.example.bitacoradigital.model.LoginResponse
 import com.example.bitacoradigital.model.SignupRequest
 import com.example.bitacoradigital.model.SignupResponse
 import com.example.bitacoradigital.model.VerifyEmailRequest
+import com.example.bitacoradigital.model.PasswordRequest
+import com.example.bitacoradigital.model.PasswordResetRequest
 import retrofit2.http.Header
 import retrofit2.http.Body
 import retrofit2.http.POST
@@ -20,6 +22,17 @@ interface AuthApi {
     suspend fun verifyEmail(
         @Header("x-session-token") token: String,
         @Body request: VerifyEmailRequest
+    ): LoginResponse
+
+    @POST("_allauth/app/v1/auth/password/request")
+    suspend fun passwordRequest(
+        @Body request: PasswordRequest
+    ): retrofit2.Response<SignupResponse>
+
+    @POST("_allauth/app/v1/auth/password/reset")
+    suspend fun passwordReset(
+        @Header("x-session-token") token: String,
+        @Body request: PasswordResetRequest
     ): LoginResponse
 
 }

--- a/app/src/main/java/com/example/bitacoradigital/ui/screens/auth/PasswordRequestScreen.kt
+++ b/app/src/main/java/com/example/bitacoradigital/ui/screens/auth/PasswordRequestScreen.kt
@@ -1,0 +1,56 @@
+package com.example.bitacoradigital.ui.screens.auth
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.input.KeyboardOptions
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.unit.dp
+import com.example.bitacoradigital.viewmodel.ForgotPasswordViewModel
+import com.example.bitacoradigital.viewmodel.SessionViewModel
+
+@Composable
+fun PasswordRequestScreen(
+    viewModel: ForgotPasswordViewModel,
+    sessionViewModel: SessionViewModel,
+    onAwaitCode: () -> Unit
+) {
+    var email by remember { mutableStateOf("") }
+    val state = viewModel.state
+
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(32.dp),
+        verticalArrangement = Arrangement.Center,
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Text("Recuperar contraseña", style = MaterialTheme.typography.headlineSmall)
+        Spacer(modifier = Modifier.height(16.dp))
+
+        OutlinedTextField(
+            value = email,
+            onValueChange = { email = it },
+            label = { Text("Correo electrónico") },
+            singleLine = true,
+            keyboardOptions = KeyboardOptions.Default.copy(keyboardType = KeyboardType.Email),
+            modifier = Modifier.fillMaxWidth()
+        )
+
+        Spacer(modifier = Modifier.height(16.dp))
+
+        Button(
+            onClick = { viewModel.requestCode(email, sessionViewModel, onAwaitCode) },
+            modifier = Modifier.fillMaxWidth()
+        ) {
+            Text("Enviar código")
+        }
+
+        state?.let {
+            Spacer(modifier = Modifier.height(8.dp))
+            Text(it, color = MaterialTheme.colorScheme.error)
+        }
+    }
+}

--- a/app/src/main/java/com/example/bitacoradigital/ui/screens/auth/PasswordResetScreen.kt
+++ b/app/src/main/java/com/example/bitacoradigital/ui/screens/auth/PasswordResetScreen.kt
@@ -1,0 +1,98 @@
+package com.example.bitacoradigital.ui.screens.auth
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Visibility
+import androidx.compose.material.icons.filled.VisibilityOff
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.input.KeyboardOptions
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.text.input.PasswordVisualTransformation
+import androidx.compose.ui.text.input.VisualTransformation
+import androidx.compose.ui.unit.dp
+import com.example.bitacoradigital.viewmodel.ForgotPasswordViewModel
+import com.example.bitacoradigital.viewmodel.HomeViewModel
+import com.example.bitacoradigital.viewmodel.SessionViewModel
+
+@Composable
+fun PasswordResetScreen(
+    viewModel: ForgotPasswordViewModel,
+    sessionViewModel: SessionViewModel,
+    homeViewModel: HomeViewModel,
+    onSuccess: () -> Unit
+) {
+    var code by remember { mutableStateOf("") }
+    var password by remember { mutableStateOf("") }
+    var confirm by remember { mutableStateOf("") }
+    var showPassword by remember { mutableStateOf(false) }
+    var localError by remember { mutableStateOf<String?>(null) }
+    val state = viewModel.state
+
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(32.dp),
+        verticalArrangement = Arrangement.Center,
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Text("Restablecer contraseña", style = MaterialTheme.typography.headlineSmall)
+        Spacer(modifier = Modifier.height(16.dp))
+
+        OutlinedTextField(
+            value = code,
+            onValueChange = { code = it },
+            label = { Text("Código") },
+            singleLine = true,
+            keyboardOptions = KeyboardOptions.Default.copy(keyboardType = KeyboardType.Text),
+            modifier = Modifier.fillMaxWidth()
+        )
+
+        OutlinedTextField(
+            value = password,
+            onValueChange = { password = it },
+            label = { Text("Nueva contraseña") },
+            singleLine = true,
+            visualTransformation = if (showPassword) VisualTransformation.None else PasswordVisualTransformation(),
+            trailingIcon = {
+                IconButton(onClick = { showPassword = !showPassword }) {
+                    Icon(imageVector = if (showPassword) Icons.Default.VisibilityOff else Icons.Default.Visibility, contentDescription = null)
+                }
+            },
+            keyboardOptions = KeyboardOptions.Default.copy(keyboardType = KeyboardType.Password),
+            modifier = Modifier.fillMaxWidth()
+        )
+
+        OutlinedTextField(
+            value = confirm,
+            onValueChange = { confirm = it },
+            label = { Text("Confirmar contraseña") },
+            singleLine = true,
+            visualTransformation = if (showPassword) VisualTransformation.None else PasswordVisualTransformation(),
+            keyboardOptions = KeyboardOptions.Default.copy(keyboardType = KeyboardType.Password),
+            modifier = Modifier.fillMaxWidth()
+        )
+
+        Spacer(modifier = Modifier.height(16.dp))
+
+        Button(
+            onClick = {
+                if (password == confirm) {
+                    viewModel.resetPassword(code, password, sessionViewModel, homeViewModel, onSuccess)
+                } else {
+                    localError = "Las contraseñas no coinciden"
+                }
+            },
+            modifier = Modifier.fillMaxWidth()
+        ) {
+            Text("Restablecer")
+        }
+
+        (state ?: localError)?.let {
+            Spacer(modifier = Modifier.height(8.dp))
+            Text(it, color = MaterialTheme.colorScheme.error)
+        }
+    }
+}

--- a/app/src/main/java/com/example/bitacoradigital/viewmodel/ForgotPasswordViewModel.kt
+++ b/app/src/main/java/com/example/bitacoradigital/viewmodel/ForgotPasswordViewModel.kt
@@ -1,0 +1,57 @@
+package com.example.bitacoradigital.viewmodel
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.setValue
+import com.example.bitacoradigital.model.PasswordRequest
+import com.example.bitacoradigital.model.PasswordResetRequest
+import com.example.bitacoradigital.model.SignupResponse
+import com.example.bitacoradigital.network.RetrofitInstance
+import com.google.gson.Gson
+import kotlinx.coroutines.launch
+
+class ForgotPasswordViewModel : ViewModel() {
+    var state by mutableStateOf<String?>(null)
+        private set
+
+    fun requestCode(email: String, sessionViewModel: SessionViewModel, onAwaitCode: () -> Unit) {
+        viewModelScope.launch {
+            try {
+                val response = RetrofitInstance.authApi.passwordRequest(PasswordRequest(email))
+                val body = if (response.isSuccessful) {
+                    response.body()
+                } else {
+                    val json = response.errorBody()?.string()
+                    json?.let { Gson().fromJson(it, SignupResponse::class.java) }
+                }
+                val token = body?.meta?.session_token
+                if (token != null) {
+                    sessionViewModel.setTemporalToken(token)
+                    state = null
+                    onAwaitCode()
+                } else {
+                    state = "Error en la respuesta"
+                }
+            } catch (e: Exception) {
+                state = "Error: ${e.localizedMessage}"
+            }
+        }
+    }
+
+    fun resetPassword(code: String, password: String, sessionViewModel: SessionViewModel, homeViewModel: HomeViewModel, onSuccess: () -> Unit) {
+        viewModelScope.launch {
+            try {
+                val token = sessionViewModel.token.value ?: return@launch
+                val response = RetrofitInstance.authApi.passwordReset(token, PasswordResetRequest(code, password))
+                sessionViewModel.guardarSesion(response.meta.session_token, response.data.user)
+                homeViewModel.cargarDesdeLogin(response.data.user, sessionViewModel)
+                state = null
+                onSuccess()
+            } catch (e: Exception) {
+                state = "Error: ${e.localizedMessage}"
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- agregar modelos `PasswordRequest` y `PasswordResetRequest`
- exponer endpoints de recuperación en `AuthApi`
- crear `ForgotPasswordViewModel` para manejar el flujo
- añadir pantallas `PasswordRequestScreen` y `PasswordResetScreen`
- integrar nuevas rutas en `NavGraph`
- conectar en `MainActivity`

## Testing
- `./gradlew help`
- `./gradlew test` *(falla por falta de Android SDK)*

------
https://chatgpt.com/codex/tasks/task_e_6849b18ae8c0832fa0a7b51b8f2914d5