### PR TITLE
Improve UI/UX with loading indicators

### DIFF
--- a/app/src/main/java/com/example/bitacoradigital/ui/screens/auth/LoginScreen.kt
+++ b/app/src/main/java/com/example/bitacoradigital/ui/screens/auth/LoginScreen.kt
@@ -2,6 +2,7 @@ package com.example.bitacoradigital.ui.screens.auth
 
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.background
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Login
@@ -34,14 +35,16 @@ fun LoginScreen(
     var password by remember { mutableStateOf("") }
     var showPassword by remember { mutableStateOf(false) }
     val loginState = loginViewModel.loginState
+    val loading = loginViewModel.loading
 
-    Column(
-        modifier = Modifier
-            .fillMaxSize()
-            .padding(horizontal = 32.dp),
-        verticalArrangement = Arrangement.Center,
-        horizontalAlignment = Alignment.CenterHorizontally
-    ) {
+    Box(Modifier.fillMaxSize()) {
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(horizontal = 32.dp),
+            verticalArrangement = Arrangement.Center,
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
         // Logo
         Text("Bitácora Digital", style = MaterialTheme.typography.headlineSmall)
         Text("Gestión de comunidades residenciales", fontSize = 14.sp, color = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.6f))
@@ -128,5 +131,17 @@ fun LoginScreen(
             color = MaterialTheme.colorScheme.primary,
             fontSize = 14.sp
         )
+        }
+
+        if (loading) {
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .background(MaterialTheme.colorScheme.background.copy(alpha = 0.5f)),
+                contentAlignment = Alignment.Center
+            ) {
+                CircularProgressIndicator()
+            }
+        }
     }
 }

--- a/app/src/main/java/com/example/bitacoradigital/ui/screens/auth/PasswordRequestScreen.kt
+++ b/app/src/main/java/com/example/bitacoradigital/ui/screens/auth/PasswordRequestScreen.kt
@@ -1,6 +1,7 @@
 package com.example.bitacoradigital.ui.screens.auth
 
 import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.background
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
@@ -19,14 +20,16 @@ fun PasswordRequestScreen(
 ) {
     var email by remember { mutableStateOf("") }
     val state = viewModel.state
+    val loading = viewModel.loading
 
-    Column(
-        modifier = Modifier
-            .fillMaxSize()
-            .padding(32.dp),
-        verticalArrangement = Arrangement.Center,
-        horizontalAlignment = Alignment.CenterHorizontally
-    ) {
+    Box(Modifier.fillMaxSize()) {
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(32.dp),
+            verticalArrangement = Arrangement.Center,
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
         Text("Recuperar contraseña", style = MaterialTheme.typography.headlineSmall)
         Spacer(modifier = Modifier.height(16.dp))
 
@@ -51,6 +54,16 @@ fun PasswordRequestScreen(
         state?.let {
             Spacer(modifier = Modifier.height(8.dp))
             Text(it, color = MaterialTheme.colorScheme.error)
+        }
+        }
+
+        if (loading) {
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .background(MaterialTheme.colorScheme.background.copy(alpha = 0.5f)),
+                contentAlignment = Alignment.Center
+            ) { CircularProgressIndicator() }
         }
     }
 }

--- a/app/src/main/java/com/example/bitacoradigital/ui/screens/auth/PasswordResetScreen.kt
+++ b/app/src/main/java/com/example/bitacoradigital/ui/screens/auth/PasswordResetScreen.kt
@@ -1,6 +1,7 @@
 package com.example.bitacoradigital.ui.screens.auth
 
 import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.background
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Visibility
 import androidx.compose.material.icons.filled.VisibilityOff
@@ -30,14 +31,16 @@ fun PasswordResetScreen(
     var showPassword by remember { mutableStateOf(false) }
     var localError by remember { mutableStateOf<String?>(null) }
     val state = viewModel.state
+    val loading = viewModel.loading
 
-    Column(
-        modifier = Modifier
-            .fillMaxSize()
-            .padding(32.dp),
-        verticalArrangement = Arrangement.Center,
-        horizontalAlignment = Alignment.CenterHorizontally
-    ) {
+    Box(Modifier.fillMaxSize()) {
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(32.dp),
+            verticalArrangement = Arrangement.Center,
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
         Text("Restablecer contraseña", style = MaterialTheme.typography.headlineSmall)
         Spacer(modifier = Modifier.height(16.dp))
 
@@ -93,6 +96,16 @@ fun PasswordResetScreen(
         (state ?: localError)?.let {
             Spacer(modifier = Modifier.height(8.dp))
             Text(it, color = MaterialTheme.colorScheme.error)
+        }
+        }
+
+        if (loading) {
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .background(MaterialTheme.colorScheme.background.copy(alpha = 0.5f)),
+                contentAlignment = Alignment.Center
+            ) { CircularProgressIndicator() }
         }
     }
 }

--- a/app/src/main/java/com/example/bitacoradigital/ui/screens/auth/SignupScreen.kt
+++ b/app/src/main/java/com/example/bitacoradigital/ui/screens/auth/SignupScreen.kt
@@ -2,6 +2,7 @@ package com.example.bitacoradigital.ui.screens.auth
 
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.background
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.PersonAdd
@@ -35,14 +36,16 @@ fun SignupScreen(
     var instancia by remember { mutableStateOf("") }
     var showPassword by remember { mutableStateOf(false) }
     val state = signupViewModel.signupState
+    val loading = signupViewModel.loading
 
-    Column(
-        modifier = Modifier
-            .fillMaxSize()
-            .padding(horizontal = 32.dp),
-        verticalArrangement = Arrangement.Center,
-        horizontalAlignment = Alignment.CenterHorizontally
-    ) {
+    Box(Modifier.fillMaxSize()) {
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(horizontal = 32.dp),
+            verticalArrangement = Arrangement.Center,
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
         Text("Registro", style = MaterialTheme.typography.headlineSmall)
         Spacer(modifier = Modifier.height(24.dp))
 
@@ -136,5 +139,15 @@ fun SignupScreen(
             color = MaterialTheme.colorScheme.primary,
             fontSize = 14.sp
         )
+        }
+
+        if (loading) {
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .background(MaterialTheme.colorScheme.background.copy(alpha = 0.5f)),
+                contentAlignment = Alignment.Center
+            ) { CircularProgressIndicator() }
+        }
     }
 }

--- a/app/src/main/java/com/example/bitacoradigital/ui/screens/auth/VerificationScreen.kt
+++ b/app/src/main/java/com/example/bitacoradigital/ui/screens/auth/VerificationScreen.kt
@@ -1,6 +1,7 @@
 package com.example.bitacoradigital.ui.screens.auth
 
 import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.background
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
@@ -21,14 +22,16 @@ fun VerificationScreen(
 ) {
     var code by remember { mutableStateOf("") }
     val state = signupViewModel.signupState
+    val loading = signupViewModel.loading
 
-    Column(
-        modifier = Modifier
-            .fillMaxSize()
-            .padding(32.dp),
-        verticalArrangement = Arrangement.Center,
-        horizontalAlignment = Alignment.CenterHorizontally
-    ) {
+    Box(Modifier.fillMaxSize()) {
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(32.dp),
+            verticalArrangement = Arrangement.Center,
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
         Text("Verifica tu correo", style = MaterialTheme.typography.headlineSmall)
         Spacer(Modifier.height(16.dp))
 
@@ -53,6 +56,16 @@ fun VerificationScreen(
         state?.let {
             Spacer(modifier = Modifier.height(8.dp))
             Text(it, color = MaterialTheme.colorScheme.error)
+        }
+        }
+
+        if (loading) {
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .background(MaterialTheme.colorScheme.background.copy(alpha = 0.5f)),
+                contentAlignment = Alignment.Center
+            ) { CircularProgressIndicator() }
         }
     }
 }

--- a/app/src/main/java/com/example/bitacoradigital/ui/screens/registrovisita/PasoConfirmacion.kt
+++ b/app/src/main/java/com/example/bitacoradigital/ui/screens/registrovisita/PasoConfirmacion.kt
@@ -4,6 +4,7 @@ package com.example.bitacoradigital.ui.screens.registrovisita
 import android.net.Uri
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.background
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.CheckCircle
@@ -37,9 +38,12 @@ fun PasoConfirmacion(viewModel: RegistroVisitaViewModel) {
     val destino by viewModel.destinoSeleccionado.collectAsState()
     val fotos by viewModel.fotosAdicionales.collectAsState()
 
-    Column(modifier = Modifier
-        .fillMaxSize()
-        .padding(16.dp)) {
+    val cargando by viewModel.cargandoRegistro.collectAsState()
+
+    Box(Modifier.fillMaxSize()) {
+        Column(modifier = Modifier
+            .fillMaxSize()
+            .padding(16.dp)) {
 
         Text("Paso 6: Confirma tu Registro", style = MaterialTheme.typography.titleLarge)
         Spacer(Modifier.height(16.dp))
@@ -97,6 +101,16 @@ fun PasoConfirmacion(viewModel: RegistroVisitaViewModel) {
             modifier = Modifier.fillMaxWidth()
         ) {
             Text("Finalizar Registro")
+        }
+        }
+
+        if (cargando) {
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .background(MaterialTheme.colorScheme.background.copy(alpha = 0.5f)),
+                contentAlignment = Alignment.Center
+            ) { CircularProgressIndicator() }
         }
     }
 }

--- a/app/src/main/java/com/example/bitacoradigital/viewmodel/ForgotPasswordViewModel.kt
+++ b/app/src/main/java/com/example/bitacoradigital/viewmodel/ForgotPasswordViewModel.kt
@@ -16,8 +16,12 @@ class ForgotPasswordViewModel : ViewModel() {
     var state by mutableStateOf<String?>(null)
         private set
 
+    var loading by mutableStateOf(false)
+        private set
+
     fun requestCode(email: String, sessionViewModel: SessionViewModel, onAwaitCode: () -> Unit) {
         viewModelScope.launch {
+            loading = true
             try {
                 val response = RetrofitInstance.authApi.passwordRequest(PasswordRequest(email))
                 val body = if (response.isSuccessful) {
@@ -36,12 +40,15 @@ class ForgotPasswordViewModel : ViewModel() {
                 }
             } catch (e: Exception) {
                 state = "Error: ${e.localizedMessage}"
+            } finally {
+                loading = false
             }
         }
     }
 
     fun resetPassword(code: String, password: String, sessionViewModel: SessionViewModel, homeViewModel: HomeViewModel, onSuccess: () -> Unit) {
         viewModelScope.launch {
+            loading = true
             try {
                 val token = sessionViewModel.token.value ?: return@launch
                 val response = RetrofitInstance.authApi.passwordReset(token, PasswordResetRequest(code, password))
@@ -51,6 +58,8 @@ class ForgotPasswordViewModel : ViewModel() {
                 onSuccess()
             } catch (e: Exception) {
                 state = "Error: ${e.localizedMessage}"
+            } finally {
+                loading = false
             }
         }
     }

--- a/app/src/main/java/com/example/bitacoradigital/viewmodel/LoginViewModel.kt
+++ b/app/src/main/java/com/example/bitacoradigital/viewmodel/LoginViewModel.kt
@@ -15,6 +15,9 @@ class LoginViewModel : ViewModel() {
     var loginState by mutableStateOf<String?>(null)
         private set
 
+    var loading by mutableStateOf(false)
+        private set
+
     fun login(
         email: String,
         password: String,
@@ -24,6 +27,7 @@ class LoginViewModel : ViewModel() {
         onAwaitCode: () -> Unit
     ) {
         viewModelScope.launch {
+            loading = true
             try {
                 val response = RetrofitInstance.authApi.login(LoginRequest(email, password))
                 val token = response.meta.session_token
@@ -55,6 +59,8 @@ class LoginViewModel : ViewModel() {
                 }
             } catch (e: Exception) {
                 loginState = "Error: ${e.localizedMessage}"
+            } finally {
+                loading = false
             }
         }
     }

--- a/app/src/main/java/com/example/bitacoradigital/viewmodel/RegistroVisitaViewModel.kt
+++ b/app/src/main/java/com/example/bitacoradigital/viewmodel/RegistroVisitaViewModel.kt
@@ -101,6 +101,9 @@ class RegistroVisitaViewModel(
     private val _errorDestino = MutableStateFlow<String?>(null)
     val errorDestino: StateFlow<String?> = _errorDestino
 
+    private val _cargandoRegistro = MutableStateFlow(false)
+    val cargandoRegistro: StateFlow<Boolean> = _cargandoRegistro
+
     fun cargarJerarquiaDestino() {
         viewModelScope.launch {
             _cargandoDestino.value = true
@@ -131,6 +134,7 @@ class RegistroVisitaViewModel(
 
     fun registrarVisita() {
         viewModelScope.launch {
+            _cargandoRegistro.value = true
             try {
                 val token = sessionPrefs.sessionToken.first() ?: throw Exception("Token vacío")
 
@@ -178,6 +182,8 @@ class RegistroVisitaViewModel(
             } catch (e: Exception) {
                 Log.e("RegistroVisita", "Excepción en el registro", e)
                 _errorDestino.value = "Error al registrar visita: ${e.localizedMessage}"
+            } finally {
+                _cargandoRegistro.value = false
             }
         }
     }

--- a/app/src/main/java/com/example/bitacoradigital/viewmodel/SignupViewModel.kt
+++ b/app/src/main/java/com/example/bitacoradigital/viewmodel/SignupViewModel.kt
@@ -17,12 +17,16 @@ class SignupViewModel : ViewModel() {
     var signupState by mutableStateOf<String?>(null)
         private set
 
+    var loading by mutableStateOf(false)
+        private set
+
     fun signup(
         request: SignupRequest,
         sessionViewModel: SessionViewModel,
         onAwaitCode: () -> Unit
     ) {
         viewModelScope.launch {
+            loading = true
             try {
                 val response = RetrofitInstance.authApi.signup(request)
                 if (response.code() == 401) {
@@ -52,6 +56,8 @@ class SignupViewModel : ViewModel() {
 
             } catch (e: Exception) {
                 signupState = "Error: ${e.localizedMessage}"
+            } finally {
+                loading = false
             }
         }
     }
@@ -63,6 +69,7 @@ class SignupViewModel : ViewModel() {
         onSuccess: () -> Unit
     ) {
         viewModelScope.launch {
+            loading = true
             try {
                 val token = sessionViewModel.token.value ?: return@launch
                 val response = RetrofitInstance.authApi.verifyEmail(token, VerifyEmailRequest(code))
@@ -72,6 +79,8 @@ class SignupViewModel : ViewModel() {
                 onSuccess()
             } catch (e: Exception) {
                 signupState = "Error: ${e.localizedMessage}"
+            } finally {
+                loading = false
             }
         }
     }


### PR DESCRIPTION
## Summary
- add loading states to viewmodels
- overlay progress indicator on auth screens
- show loading indicator when registering visits

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849b8296cac832f8e71b49e6e00eb52