### PR TITLE
Add auto session refresh

### DIFF
--- a/app/src/main/java/com/example/bitacoradigital/network/AuthApi.kt
+++ b/app/src/main/java/com/example/bitacoradigital/network/AuthApi.kt
@@ -9,6 +9,7 @@ import com.example.bitacoradigital.model.PasswordRequest
 import com.example.bitacoradigital.model.PasswordResetRequest
 import retrofit2.http.Header
 import retrofit2.http.Body
+import retrofit2.http.GET
 import retrofit2.http.POST
 
 interface AuthApi {
@@ -35,5 +36,9 @@ interface AuthApi {
         @Body request: PasswordResetRequest
     ): retrofit2.Response<LoginResponse>
 
+    @GET("_allauth/app/v1/auth/session")
+    suspend fun getSession(
+        @Header("x-session-token") token: String
+    ): LoginResponse
 
 }


### PR DESCRIPTION
## Summary
- hit session refresh API in `AuthApi`
- periodically update session data in `SessionViewModel`

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a0cc96994832f91cab816584ef57f