### PR TITLE
Fix FileProvider authority string

### DIFF
--- a/app/src/main/java/com/example/bitacoradigital/ui/screens/registrovisita/PasoDocumento.kt
+++ b/app/src/main/java/com/example/bitacoradigital/ui/screens/registrovisita/PasoDocumento.kt
@@ -33,7 +33,11 @@ fun PasoDocumento(viewModel: RegistroVisitaViewModel) {
     fun createImageUri(context: Context): Uri {
         val imagesDir = File(context.cacheDir, "images").apply { mkdirs() }
         val image = File.createTempFile("document_", ".jpg", imagesDir)
-        return FileProvider.getUriForFile(context, "${'$'}{context.packageName}.fileprovider", image)
+        return FileProvider.getUriForFile(
+            context,
+            "${context.packageName}.fileprovider",
+            image
+        )
     }
 
     val launcher = rememberLauncherForActivityResult(

--- a/app/src/main/java/com/example/bitacoradigital/ui/screens/registrovisita/PasoFotos.kt
+++ b/app/src/main/java/com/example/bitacoradigital/ui/screens/registrovisita/PasoFotos.kt
@@ -46,7 +46,11 @@ fun PasoFotos(viewModel: RegistroVisitaViewModel) {
     fun createImageUri(context: Context): Uri {
         val imagesDir = File(context.cacheDir, "images").apply { mkdirs() }
         val image = File.createTempFile("extra_", ".jpg", imagesDir)
-        return FileProvider.getUriForFile(context, "${'$'}{context.packageName}.fileprovider", image)
+        return FileProvider.getUriForFile(
+            context,
+            "${context.packageName}.fileprovider",
+            image
+        )
     }
 
     val launcher = rememberLauncherForActivityResult(


### PR DESCRIPTION
## Summary
- ensure context package name is interpolated when creating URIs

## Testing
- `sh gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a1e47a8c8832f8cf1b3248b5812e2