### PR TITLE
Fix session refresh logic

### DIFF
--- a/app/src/main/java/com/example/bitacoradigital/model/LoginResponse.kt
+++ b/app/src/main/java/com/example/bitacoradigital/model/LoginResponse.kt
@@ -55,5 +55,5 @@ data class AuthMethod(
 
 data class Meta(
     val is_authenticated: Boolean,
-    val session_token: String
+    val session_token: String? = null
 )

--- a/app/src/main/java/com/example/bitacoradigital/model/SignupResponse.kt
+++ b/app/src/main/java/com/example/bitacoradigital/model/SignupResponse.kt
@@ -17,5 +17,5 @@ data class SignupFlow(
 
 data class SignupMeta(
     val is_authenticated: Boolean,
-    val session_token: String
+    val session_token: String? = null
 )

--- a/app/src/main/java/com/example/bitacoradigital/viewmodel/ForgotPasswordViewModel.kt
+++ b/app/src/main/java/com/example/bitacoradigital/viewmodel/ForgotPasswordViewModel.kt
@@ -57,7 +57,8 @@ class ForgotPasswordViewModel : ViewModel() {
                 if (response.isSuccessful) {
                     val body = response.body()
                     if (body != null) {
-                        sessionViewModel.guardarSesion(body.meta.session_token, body.data.user)
+                        val newToken = body.meta.session_token ?: token
+                        sessionViewModel.guardarSesion(newToken, body.data.user)
                         state = null
                         onSuccess()
                     } else {

--- a/app/src/main/java/com/example/bitacoradigital/viewmodel/LoginViewModel.kt
+++ b/app/src/main/java/com/example/bitacoradigital/viewmodel/LoginViewModel.kt
@@ -33,6 +33,11 @@ class LoginViewModel : ViewModel() {
                 val token = response.meta.session_token
                 val user = response.data.user
 
+                if (token == null) {
+                    loginState = "Respuesta inesperada"
+                    return@launch
+                }
+
                 if (user.empresas.any { it.B }) {
                     sessionViewModel.guardarSesion(token, user)
                     loginState = "Login exitoso"

--- a/app/src/main/java/com/example/bitacoradigital/viewmodel/SessionViewModel.kt
+++ b/app/src/main/java/com/example/bitacoradigital/viewmodel/SessionViewModel.kt
@@ -32,6 +32,7 @@ class SessionViewModel(application: Application) : AndroidViewModel(application)
     val favoritoEmpresaId = prefs.favoritoEmpresaId
     val favoritoPerimetroId = prefs.favoritoPerimetroId
 
+    // Check for updates periodically without replacing the current token
     private val REFRESH_INTERVAL_MS = 5 * 60 * 1000L // 5 minutes
 
 
@@ -70,7 +71,8 @@ class SessionViewModel(application: Application) : AndroidViewModel(application)
                 if (!token.isNullOrBlank()) {
                     try {
                         val response = RetrofitInstance.authApi.getSession(token)
-                        guardarSesion(response.meta.session_token, response.data.user)
+                        val newToken = response.meta.session_token ?: token
+                        guardarSesion(newToken, response.data.user)
                     } catch (_: Exception) {
                         // Ignorar errores de refresco
                     }

--- a/app/src/main/java/com/example/bitacoradigital/viewmodel/SignupViewModel.kt
+++ b/app/src/main/java/com/example/bitacoradigital/viewmodel/SignupViewModel.kt
@@ -73,7 +73,8 @@ class SignupViewModel : ViewModel() {
             try {
                 val token = sessionViewModel.token.value ?: return@launch
                 val response = RetrofitInstance.authApi.verifyEmail(token, VerifyEmailRequest(code))
-                sessionViewModel.guardarSesion(response.meta.session_token, response.data.user)
+                val newToken = response.meta.session_token ?: token
+                sessionViewModel.guardarSesion(newToken, response.data.user)
                 homeViewModel.cargarDesdeLogin(response.data.user, sessionViewModel)
                 signupState = null
                 onSuccess()


### PR DESCRIPTION
## Summary
- keep existing token when backend doesn't return a new one
- allow missing `session_token` in API models

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a93a8ae64832f83e1c6c0ee8f620f