### PR TITLE
Fix FileProvider authority

### DIFF
--- a/app/src/main/java/com/example/bitacoradigital/ui/screens/registrovisita/PasoDocumento.kt
+++ b/app/src/main/java/com/example/bitacoradigital/ui/screens/registrovisita/PasoDocumento.kt
@@ -5,6 +5,7 @@ import android.net.Uri
 import android.Manifest
 import android.content.pm.PackageManager
 import androidx.core.content.FileProvider
+import com.example.bitacoradigital.util.Constants
 import androidx.core.content.ContextCompat
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
@@ -53,7 +54,7 @@ fun PasoDocumento(viewModel: RegistroVisitaViewModel) {
         val image = File.createTempFile("document_", ".jpg", imagesDir)
         return FileProvider.getUriForFile(
             context,
-            "${context.packageName}.fileprovider",
+            Constants.FILE_PROVIDER_AUTHORITY,
             image
         )
     }

--- a/app/src/main/java/com/example/bitacoradigital/ui/screens/registrovisita/PasoFotos.kt
+++ b/app/src/main/java/com/example/bitacoradigital/ui/screens/registrovisita/PasoFotos.kt
@@ -35,6 +35,7 @@ import androidx.compose.ui.unit.dp
 import com.example.bitacoradigital.viewmodel.RegistroVisitaViewModel
 import android.content.Context
 import androidx.core.content.FileProvider
+import com.example.bitacoradigital.util.Constants
 import androidx.core.content.ContextCompat
 import java.io.File
 import android.net.Uri
@@ -66,7 +67,7 @@ fun PasoFotos(viewModel: RegistroVisitaViewModel) {
         val image = File.createTempFile("extra_", ".jpg", imagesDir)
         return FileProvider.getUriForFile(
             context,
-            "${context.packageName}.fileprovider",
+            Constants.FILE_PROVIDER_AUTHORITY,
             image
         )
     }

--- a/app/src/main/java/com/example/bitacoradigital/util/Constants.kt
+++ b/app/src/main/java/com/example/bitacoradigital/util/Constants.kt
@@ -1,0 +1,7 @@
+package com.example.bitacoradigital.util
+
+import com.example.bitacoradigital.BuildConfig
+
+object Constants {
+    val FILE_PROVIDER_AUTHORITY: String = "${BuildConfig.APPLICATION_ID}.fileprovider"
+}


### PR DESCRIPTION
## Summary
- centralize FileProvider authority
- use constant in PasoDocumento and PasoFotos

## Testing
- `./gradlew test --dry-run` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_684aec7959b8832f813a46e96ccc2489