### PR TITLE
Fix BuildConfig reference error

### DIFF
--- a/app/src/main/java/com/example/bitacoradigital/util/Constants.kt
+++ b/app/src/main/java/com/example/bitacoradigital/util/Constants.kt
@@ -1,7 +1,5 @@
 package com.example.bitacoradigital.util
 
-import com.example.bitacoradigital.BuildConfig
-
 object Constants {
-    val FILE_PROVIDER_AUTHORITY: String = "${BuildConfig.APPLICATION_ID}.fileprovider"
+    const val FILE_PROVIDER_AUTHORITY: String = "com.example.bitacoradigital.fileprovider"
 }


### PR DESCRIPTION
## Summary
- remove `BuildConfig` import
- inline FILE_PROVIDER_AUTHORITY constant

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_684aeeda4848832f80048b07948340ca