### PR TITLE
Remove timeouts for document upload

### DIFF
--- a/app/src/main/java/com/example/bitacoradigital/viewmodel/RegistroVisitaViewModel.kt
+++ b/app/src/main/java/com/example/bitacoradigital/viewmodel/RegistroVisitaViewModel.kt
@@ -24,6 +24,7 @@ import okhttp3.RequestBody.Companion.toRequestBody
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import okhttp3.OkHttpClient
+import java.util.concurrent.TimeUnit
 import org.json.JSONObject
 import java.text.SimpleDateFormat
 import java.util.Date
@@ -212,7 +213,15 @@ class RegistroVisitaViewModel(
                 .addHeader("accept", "application/json")
                 .build()
 
-            val client = OkHttpClient()
+            // The backend may take considerable time to process the image.
+            // Remove timeouts on the HTTP client so the request isn't aborted
+            // before the server responds.
+            val client = OkHttpClient.Builder()
+                .connectTimeout(0, TimeUnit.MILLISECONDS)
+                .readTimeout(0, TimeUnit.MILLISECONDS)
+                .writeTimeout(0, TimeUnit.MILLISECONDS)
+                .callTimeout(0, TimeUnit.MILLISECONDS)
+                .build()
             val response = withContext(Dispatchers.IO) { client.newCall(request).execute() }
 
             if (response.isSuccessful) {


### PR DESCRIPTION
## Summary
- ensure document upload uses OkHttp client with no timeouts so long operations don't fail

## Testing
- `./gradlew test --no-daemon` *(fails: could not run due to missing Android tooling)*

------
https://chatgpt.com/codex/tasks/task_e_684c544ffe94832fae485d9738b89cc4