### PR TITLE
Add authorization header for recognition endpoint

### DIFF
--- a/app/src/main/java/com/example/bitacoradigital/viewmodel/RegistroVisitaViewModel.kt
+++ b/app/src/main/java/com/example/bitacoradigital/viewmodel/RegistroVisitaViewModel.kt
@@ -210,6 +210,7 @@ class RegistroVisitaViewModel(
             val request = Request.Builder()
                 .url("https://bit.cs3.mx/credential/recognition")
                 .post(multipart)
+                .addHeader("Authorization", "Bearer MHIxMG4hQ2gxbjAjTHUxJF9LQHQwLUYzci5WMWMwKkNAJF8zbTF4SkAxbTMrMCRjQHJfMXJ2MW45DQoNCg")
                 .addHeader("accept", "application/json")
                 .build()
 


### PR DESCRIPTION
## Summary
- include `Authorization` bearer token header when posting to the recognition endpoint

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6850393100f4832f9c417e36f8360421