### PR TITLE
Fix error message format

### DIFF
--- a/app/src/main/java/com/example/bitacoradigital/viewmodel/GenerarCodigoQRViewModel.kt
+++ b/app/src/main/java/com/example/bitacoradigital/viewmodel/GenerarCodigoQRViewModel.kt
@@ -50,7 +50,7 @@ class GenerarCodigoQRViewModel(private val prefs: SessionPreferences) : ViewMode
                     "Error ${'$'}{response.code}"
                 }
             } catch (e: Exception) {
-                _mensaje.value = "Error al enviar invitación: ${'$'}{e.message ?: e.toString()}"
+                _mensaje.value = "Error al enviar invitación: ${e.message ?: e.toString()}"
             } finally {
                 _cargando.value = false
             }


### PR DESCRIPTION
## Summary
- correct string interpolation in QR invitation error handling

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6850d537704c832fa885a533e44a4350