### PR TITLE
Improve error UX and add persistent bottom navigation

### DIFF
--- a/app/src/main/java/com/example/bitacoradigital/navigation/NavGraph.kt
+++ b/app/src/main/java/com/example/bitacoradigital/navigation/NavGraph.kt
@@ -119,7 +119,7 @@ fun AppNavGraph(
         composable("visitas/manual") {
             val perimetroId = homeViewModel.perimetroSeleccionado.value?.perimetroId ?: return@composable
 
-            RegistroVisitaWizardScreen(perimetroId = perimetroId) // ← ya no pases nada aquí
+            RegistroVisitaWizardScreen(perimetroId = perimetroId, navController = navController)
         }
 
         composable("visitas/qr") {
@@ -134,7 +134,7 @@ fun AppNavGraph(
         }
 
         composable("qr/generar") {
-            GenerarCodigoQRScreen()
+            GenerarCodigoQRScreen(navController)
         }
 
         composable("perimetros") {

--- a/app/src/main/java/com/example/bitacoradigital/ui/components/HomeConfigNavBar.kt
+++ b/app/src/main/java/com/example/bitacoradigital/ui/components/HomeConfigNavBar.kt
@@ -1,0 +1,31 @@
+package com.example.bitacoradigital.ui.components
+
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Home
+import androidx.compose.material.icons.filled.Settings
+import androidx.compose.material3.NavigationBar
+import androidx.compose.material3.NavigationBarItem
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+
+@Composable
+fun HomeConfigNavBar(
+    current: String,
+    onHomeClick: () -> Unit,
+    onConfigClick: () -> Unit
+) {
+    NavigationBar {
+        NavigationBarItem(
+            selected = current == "home",
+            onClick = onHomeClick,
+            icon = { androidx.compose.material3.Icon(Icons.Default.Home, contentDescription = "Home") },
+            label = { Text("Home") }
+        )
+        NavigationBarItem(
+            selected = current == "config",
+            onClick = onConfigClick,
+            icon = { androidx.compose.material3.Icon(Icons.Default.Settings, contentDescription = "Configuración") },
+            label = { Text("Configuración") }
+        )
+    }
+}

--- a/app/src/main/java/com/example/bitacoradigital/ui/screens/ConfiguracionScreen.kt
+++ b/app/src/main/java/com/example/bitacoradigital/ui/screens/ConfiguracionScreen.kt
@@ -14,6 +14,7 @@ import androidx.compose.ui.unit.dp
 import com.example.bitacoradigital.model.User
 import com.example.bitacoradigital.viewmodel.SessionViewModel
 import kotlinx.coroutines.launch
+import com.example.bitacoradigital.ui.components.HomeConfigNavBar
 
 @Composable
 fun ConfiguracionScreen(
@@ -25,20 +26,11 @@ fun ConfiguracionScreen(
 
     Scaffold(
         bottomBar = {
-            NavigationBar {
-                NavigationBarItem(
-                    selected = false,
-                    onClick = onHomeClick,
-                    icon = { Icon(Icons.Default.Home, contentDescription = "Home") },
-                    label = { Text("Home") }
-                )
-                NavigationBarItem(
-                    selected = true,
-                    onClick = { /* Ya estás en Configuración */ },
-                    icon = { Icon(Icons.Default.Settings, contentDescription = "Configuración") },
-                    label = { Text("Configuración") }
-                )
-            }
+            HomeConfigNavBar(
+                current = "config",
+                onHomeClick = onHomeClick,
+                onConfigClick = {}
+            )
         }
     ) { innerPadding ->
         Column(

--- a/app/src/main/java/com/example/bitacoradigital/ui/screens/HomeScreen.kt
+++ b/app/src/main/java/com/example/bitacoradigital/ui/screens/HomeScreen.kt
@@ -18,6 +18,7 @@ import androidx.navigation.NavHostController
 import com.example.bitacoradigital.model.PerimetroVisual
 import com.example.bitacoradigital.viewmodel.HomeViewModel
 import com.example.bitacoradigital.viewmodel.SessionViewModel
+import com.example.bitacoradigital.ui.components.HomeConfigNavBar
 
 @Composable
 fun HomeScreen(
@@ -43,7 +44,11 @@ fun HomeScreen(
             )
         },
         bottomBar = {
-            BottomNavigationBar(onConfiguracionClick = onConfiguracionClick)
+            HomeConfigNavBar(
+                current = "home",
+                onHomeClick = {},
+                onConfigClick = onConfiguracionClick
+            )
         }
     ) { innerPadding ->
         val scrollState = rememberScrollState()
@@ -178,22 +183,4 @@ fun TopBar(
             }
         }
     )
-}
-
-@Composable
-fun BottomNavigationBar(onConfiguracionClick: () -> Unit) {
-    NavigationBar {
-        NavigationBarItem(
-            selected = true,
-            onClick = { /* Ya estás en Home */ },
-            icon = { Icon(Icons.Default.Home, contentDescription = "Home") },
-            label = { Text("Home") }
-        )
-        NavigationBarItem(
-            selected = false,
-            onClick = onConfiguracionClick,
-            icon = { Icon(Icons.Default.Settings, contentDescription = "Configuración") },
-            label = { Text("Configuración") }
-        )
-    }
 }

--- a/app/src/main/java/com/example/bitacoradigital/ui/screens/RegistroVisitaWizardScreen.kt
+++ b/app/src/main/java/com/example/bitacoradigital/ui/screens/RegistroVisitaWizardScreen.kt
@@ -22,10 +22,12 @@ import com.example.bitacoradigital.ui.screens.registrovisita.PasoTelefono
 import com.example.bitacoradigital.ui.screens.registrovisita.PasoVerificacion
 import com.example.bitacoradigital.viewmodel.RegistroVisitaViewModelFactory
 import com.example.bitacoradigital.ui.components.Stepper
+import com.example.bitacoradigital.ui.components.HomeConfigNavBar
+import androidx.navigation.NavHostController
 
 
 @Composable
-fun RegistroVisitaWizardScreen(perimetroId: Int) {
+fun RegistroVisitaWizardScreen(perimetroId: Int, navController: NavHostController) {
     val context = LocalContext.current
     val apiService = remember { ApiService.create() }
     val sessionPrefs = remember { SessionPreferences(context) }
@@ -36,7 +38,16 @@ fun RegistroVisitaWizardScreen(perimetroId: Int) {
 
     val pasoActual by viewModel.pasoActual.collectAsState()
 
-    Column(modifier = Modifier.fillMaxSize().padding(16.dp)) {
+    Scaffold(
+        bottomBar = {
+            HomeConfigNavBar(
+                current = "",
+                onHomeClick = { navController.navigate("home") },
+                onConfigClick = { navController.navigate("configuracion") }
+            )
+        }
+    ) { innerPadding ->
+    Column(modifier = Modifier.fillMaxSize().padding(innerPadding).padding(16.dp)) {
         Stepper(pasoActual, totalPasos = 7)
         Spacer(Modifier.height(24.dp))
 
@@ -49,5 +60,6 @@ fun RegistroVisitaWizardScreen(perimetroId: Int) {
             6 -> PasoConfirmacion(viewModel)
             7 -> PasoFinal(viewModel)
         }
+    }
     }
 }

--- a/app/src/main/java/com/example/bitacoradigital/ui/screens/VisitasScreen.kt
+++ b/app/src/main/java/com/example/bitacoradigital/ui/screens/VisitasScreen.kt
@@ -19,16 +19,26 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.compose.ui.text.font.FontWeight
 import androidx.navigation.NavHostController
-import androidx.navigation.compose.rememberNavController
+import com.example.bitacoradigital.ui.components.HomeConfigNavBar
 
 @Composable
 fun VisitasScreen(
     permisos: List<String>,
     navController: NavHostController
 ) {
+    Scaffold(
+        bottomBar = {
+            HomeConfigNavBar(
+                current = "",
+                onHomeClick = { navController.navigate("home") },
+                onConfigClick = { navController.navigate("configuracion") }
+            )
+        }
+    ) { innerPadding ->
     Column(
         modifier = Modifier
             .fillMaxSize()
+            .padding(innerPadding)
             .padding(16.dp),
         verticalArrangement = Arrangement.spacedBy(16.dp)
     ) {

--- a/app/src/main/java/com/example/bitacoradigital/ui/screens/auth/LoginScreen.kt
+++ b/app/src/main/java/com/example/bitacoradigital/ui/screens/auth/LoginScreen.kt
@@ -18,6 +18,8 @@ import androidx.compose.ui.unit.sp
 import com.example.bitacoradigital.viewmodel.HomeViewModel
 import com.example.bitacoradigital.viewmodel.LoginViewModel
 import com.example.bitacoradigital.viewmodel.SessionViewModel
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
 
 @Composable
 fun LoginScreen(
@@ -36,6 +38,7 @@ fun LoginScreen(
     var showPassword by remember { mutableStateOf(false) }
     val loginState = loginViewModel.loginState
     val loading = loginViewModel.loading
+    val snackbarHostState = remember { SnackbarHostState() }
 
     Box(Modifier.fillMaxSize()) {
         Column(
@@ -110,8 +113,11 @@ fun LoginScreen(
 
         Spacer(modifier = Modifier.height(8.dp))
 
-        loginState?.let {
-            Text(it, color = if (it.contains("Error")) MaterialTheme.colorScheme.error else MaterialTheme.colorScheme.primary)
+        loginState?.let { msg ->
+            LaunchedEffect(msg) {
+                snackbarHostState.showSnackbar(msg)
+                loginViewModel.clearState()
+            }
         }
 
         Text(
@@ -132,6 +138,8 @@ fun LoginScreen(
             fontSize = 14.sp
         )
         }
+
+        SnackbarHost(hostState = snackbarHostState, modifier = Modifier.align(Alignment.BottomCenter))
 
         if (loading) {
             Box(

--- a/app/src/main/java/com/example/bitacoradigital/ui/screens/dashboard/DashboardScreen.kt
+++ b/app/src/main/java/com/example/bitacoradigital/ui/screens/dashboard/DashboardScreen.kt
@@ -7,16 +7,29 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
+import com.example.bitacoradigital.ui.components.HomeConfigNavBar
+import androidx.navigation.NavHostController
 
 @Composable
 fun DashboardScreen(
-    viewModel: DashboardViewModel = viewModel()
+    viewModel: DashboardViewModel = viewModel(),
+    navController: NavHostController
 ) {
     val state = viewModel.uiState.collectAsState().value
 
+    Scaffold(
+        bottomBar = {
+            HomeConfigNavBar(
+                current = "",
+                onHomeClick = { navController.navigate("home") },
+                onConfigClick = { navController.navigate("configuracion") }
+            )
+        }
+    ) { innerPadding ->
     Column(
         modifier = Modifier
             .fillMaxSize()
+            .padding(innerPadding)
             .padding(24.dp),
         verticalArrangement = Arrangement.spacedBy(16.dp)
     ) {
@@ -48,5 +61,6 @@ fun DashboardScreen(
                 Text("Último escaneo: ${state.ultimoEvento}")
             }
         }
+    }
     }
 }

--- a/app/src/main/java/com/example/bitacoradigital/ui/screens/perimetro/PerimetrosScreen.kt
+++ b/app/src/main/java/com/example/bitacoradigital/ui/screens/perimetro/PerimetrosScreen.kt
@@ -18,9 +18,11 @@ import com.example.bitacoradigital.network.ApiService
 import com.example.bitacoradigital.viewmodel.PerimetroViewModel
 import com.example.bitacoradigital.viewmodel.PerimetroViewModelFactory
 import com.example.bitacoradigital.model.JerarquiaNodo
+import com.example.bitacoradigital.ui.components.HomeConfigNavBar
+import androidx.navigation.NavHostController
 
 @Composable
-fun PerimetrosScreen(perimetroId: Int, permisos: List<String>) {
+fun PerimetrosScreen(perimetroId: Int, permisos: List<String>, navController: NavHostController) {
     val context = LocalContext.current
     val apiService = remember { ApiService.create() }
     val prefs = remember { SessionPreferences(context) }
@@ -43,8 +45,25 @@ fun PerimetrosScreen(perimetroId: Int, permisos: List<String>) {
     var nombreSubzona by remember { mutableStateOf("") }
 
     LaunchedEffect(Unit) { viewModel.cargarJerarquia() }
+    val snackbarHostState = remember { SnackbarHostState() }
+    error?.let { msg ->
+        LaunchedEffect(msg) {
+            snackbarHostState.showSnackbar(msg)
+            viewModel.clearError()
+        }
+    }
 
-    Column(Modifier.fillMaxSize().padding(16.dp)) {
+    Scaffold(
+        bottomBar = {
+            HomeConfigNavBar(
+                current = "",
+                onHomeClick = { navController.navigate("home") },
+                onConfigClick = { navController.navigate("configuracion") }
+            )
+        },
+        snackbarHost = { SnackbarHost(snackbarHostState) }
+    ) { innerPadding ->
+    Column(Modifier.fillMaxSize().padding(innerPadding).padding(16.dp)) {
         if (cargando) {
             CircularProgressIndicator()
         } else if (error != null) {

--- a/app/src/main/java/com/example/bitacoradigital/ui/screens/qr/CodigosQRScreen.kt
+++ b/app/src/main/java/com/example/bitacoradigital/ui/screens/qr/CodigosQRScreen.kt
@@ -20,12 +20,23 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavHostController
+import com.example.bitacoradigital.ui.components.HomeConfigNavBar
 
 @Composable
 fun CodigosQRScreen(permisos: List<String>, navController: NavHostController) {
+    Scaffold(
+        bottomBar = {
+            HomeConfigNavBar(
+                current = "",
+                onHomeClick = { navController.navigate("home") },
+                onConfigClick = { navController.navigate("configuracion") }
+            )
+        }
+    ) { innerPadding ->
     Column(
         modifier = Modifier
             .fillMaxSize()
+            .padding(innerPadding)
             .padding(16.dp),
         verticalArrangement = Arrangement.spacedBy(16.dp)
     ) {
@@ -42,6 +53,7 @@ fun CodigosQRScreen(permisos: List<String>, navController: NavHostController) {
                 onClick = { navController.navigate("qr/generar") }
             )
         }
+    }
     }
 }
 

--- a/app/src/main/java/com/example/bitacoradigital/ui/screens/qr/GenerarCodigoQRScreen.kt
+++ b/app/src/main/java/com/example/bitacoradigital/ui/screens/qr/GenerarCodigoQRScreen.kt
@@ -15,9 +15,11 @@ import androidx.lifecycle.viewmodel.compose.viewModel
 import com.example.bitacoradigital.data.SessionPreferences
 import com.example.bitacoradigital.viewmodel.GenerarCodigoQRViewModel
 import com.example.bitacoradigital.viewmodel.GenerarCodigoQRViewModelFactory
+import com.example.bitacoradigital.ui.components.HomeConfigNavBar
+import androidx.navigation.NavHostController
 
 @Composable
-fun GenerarCodigoQRScreen() {
+fun GenerarCodigoQRScreen(navController: NavHostController) {
     val context = LocalContext.current
     val prefs = remember { SessionPreferences(context) }
     val viewModel: GenerarCodigoQRViewModel = viewModel(factory = GenerarCodigoQRViewModelFactory(prefs))
@@ -27,9 +29,19 @@ fun GenerarCodigoQRScreen() {
     val mensaje by viewModel.mensaje.collectAsState()
     val cargando by viewModel.cargando.collectAsState()
 
+    Scaffold(
+        bottomBar = {
+            HomeConfigNavBar(
+                current = "",
+                onHomeClick = { navController.navigate("home") },
+                onConfigClick = { navController.navigate("configuracion") }
+            )
+        }
+    ) { innerPadding ->
     Column(
         modifier = Modifier
             .fillMaxSize()
+            .padding(innerPadding)
             .padding(16.dp),
         verticalArrangement = Arrangement.spacedBy(16.dp, Alignment.CenterVertically),
         horizontalAlignment = Alignment.CenterHorizontally
@@ -56,5 +68,6 @@ fun GenerarCodigoQRScreen() {
         }
 
         mensaje?.let { Text(it) }
+    }
     }
 }

--- a/app/src/main/java/com/example/bitacoradigital/ui/screens/registrovisita/PasoDestino.kt
+++ b/app/src/main/java/com/example/bitacoradigital/ui/screens/registrovisita/PasoDestino.kt
@@ -9,6 +9,8 @@ import androidx.compose.ui.Alignment
 import com.example.bitacoradigital.model.JerarquiaNodo
 import androidx.compose.ui.unit.dp
 import com.example.bitacoradigital.viewmodel.RegistroVisitaViewModel
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
 
 @Composable
 fun PasoDestino(viewModel: RegistroVisitaViewModel) {
@@ -17,22 +19,29 @@ fun PasoDestino(viewModel: RegistroVisitaViewModel) {
     val seleccionActual by viewModel.destinoSeleccionado.collectAsState()
     val cargando by viewModel.cargandoDestino.collectAsState()
     val error by viewModel.errorDestino.collectAsState()
+    val snackbarHostState = remember { SnackbarHostState() }
 
     LaunchedEffect(Unit) {
         viewModel.cargarJerarquiaDestino()
 
     }
 
-    Column(modifier = Modifier
-        .fillMaxSize()
-        .padding(16.dp)) {
+    Box(Modifier.fillMaxSize()) {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(16.dp)
+    ) {
         Text("Paso 4: Selección de Destino", style = MaterialTheme.typography.titleLarge)
         Spacer(modifier = Modifier.height(16.dp))
 
         if (cargando) {
             CircularProgressIndicator()
         } else if (error != null) {
-            Text("Error: $error", color = MaterialTheme.colorScheme.error)
+            LaunchedEffect(error) {
+                snackbarHostState.showSnackbar(error ?: "")
+                viewModel.clearDestinoError()
+            }
         } else {
             NavegacionJerarquia(
                 ruta = ruta,
@@ -44,6 +53,8 @@ fun PasoDestino(viewModel: RegistroVisitaViewModel) {
                 onRetroceder = { viewModel.retrocederNivel() }
             )
         }
+    }
+    SnackbarHost(hostState = snackbarHostState, modifier = Modifier.align(Alignment.BottomCenter))
     }
 }
 

--- a/app/src/main/java/com/example/bitacoradigital/ui/screens/registrovisita/PasoDocumento.kt
+++ b/app/src/main/java/com/example/bitacoradigital/ui/screens/registrovisita/PasoDocumento.kt
@@ -24,12 +24,15 @@ import java.io.File
 import com.example.bitacoradigital.viewmodel.RegistroVisitaViewModel
 import androidx.compose.runtime.rememberCoroutineScope
 import kotlinx.coroutines.launch
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
 @Composable
 fun PasoDocumento(viewModel: RegistroVisitaViewModel) {
     val context = LocalContext.current
     val uri = viewModel.documentoUri.value
     val cargando by viewModel.cargandoReconocimiento.collectAsState()
     val error by viewModel.errorReconocimiento.collectAsState()
+    val snackbarHostState = remember { SnackbarHostState() }
     val coroutineScope = rememberCoroutineScope()
 
     var hasCameraPermission by remember {
@@ -67,6 +70,7 @@ fun PasoDocumento(viewModel: RegistroVisitaViewModel) {
         }
     }
 
+    Box(Modifier.fillMaxSize()) {
     Column(modifier = Modifier.padding(16.dp)) {
         Text("Paso 2: Escanea tu documento", style = MaterialTheme.typography.titleLarge)
         Spacer(modifier = Modifier.height(16.dp))
@@ -119,14 +123,18 @@ fun PasoDocumento(viewModel: RegistroVisitaViewModel) {
             Text(if (cargando) "Procesando..." else "Continuar")
         }
 
-        error?.let {
-            Spacer(modifier = Modifier.height(8.dp))
-            Text(it, color = MaterialTheme.colorScheme.error)
+        error?.let { msg ->
+            LaunchedEffect(msg) {
+                snackbarHostState.showSnackbar(msg)
+                viewModel.clearReconocimientoError()
+            }
         }
 
         if (cargando) {
             Spacer(modifier = Modifier.height(16.dp))
             CircularProgressIndicator()
         }
+    }
+    SnackbarHost(hostState = snackbarHostState, modifier = Modifier.align(Alignment.BottomCenter))
     }
 }

--- a/app/src/main/java/com/example/bitacoradigital/ui/screens/registrovisita/PasoTelefono.kt
+++ b/app/src/main/java/com/example/bitacoradigital/ui/screens/registrovisita/PasoTelefono.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
 import com.example.bitacoradigital.viewmodel.RegistroVisitaViewModel
@@ -18,12 +19,16 @@ fun PasoTelefono(viewModel: RegistroVisitaViewModel) {
 
     var cargando by remember { mutableStateOf(false) }
     var mensajeError by remember { mutableStateOf<String?>(null) }
+    val snackbarHostState = remember { SnackbarHostState() }
 
     val coroutineScope = rememberCoroutineScope()
 
-    Column(modifier = Modifier
-        .fillMaxSize()
-        .padding(16.dp)) {
+    Box(Modifier.fillMaxSize()) {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(16.dp)
+    ) {
 
         Text("Paso 1: Verificación de teléfono", style = MaterialTheme.typography.titleLarge)
         Spacer(modifier = Modifier.height(16.dp))
@@ -71,9 +76,13 @@ fun PasoTelefono(viewModel: RegistroVisitaViewModel) {
             }
         }
 
-        mensajeError?.let {
-            Spacer(modifier = Modifier.height(8.dp))
-            Text(it, color = MaterialTheme.colorScheme.error)
+        mensajeError?.let { msg ->
+            LaunchedEffect(msg) {
+                snackbarHostState.showSnackbar(msg)
+                mensajeError = null
+            }
         }
+    }
+    SnackbarHost(hostState = snackbarHostState, modifier = Modifier.align(Alignment.BottomCenter))
     }
 }

--- a/app/src/main/java/com/example/bitacoradigital/viewmodel/LoginViewModel.kt
+++ b/app/src/main/java/com/example/bitacoradigital/viewmodel/LoginViewModel.kt
@@ -18,6 +18,10 @@ class LoginViewModel : ViewModel() {
     var loading by mutableStateOf(false)
         private set
 
+    fun clearState() {
+        loginState = null
+    }
+
     fun login(
         email: String,
         password: String,

--- a/app/src/main/java/com/example/bitacoradigital/viewmodel/PerimetroViewModel.kt
+++ b/app/src/main/java/com/example/bitacoradigital/viewmodel/PerimetroViewModel.kt
@@ -37,6 +37,10 @@ class PerimetroViewModel(
     private val _error = MutableStateFlow<String?>(null)
     val error: StateFlow<String?> = _error.asStateFlow()
 
+    fun clearError() {
+        _error.value = null
+    }
+
     fun cargarJerarquia() {
         viewModelScope.launch {
             _cargando.value = true

--- a/app/src/main/java/com/example/bitacoradigital/viewmodel/RegistroVisitaViewModel.kt
+++ b/app/src/main/java/com/example/bitacoradigital/viewmodel/RegistroVisitaViewModel.kt
@@ -159,6 +159,14 @@ class RegistroVisitaViewModel(
     private val _errorReconocimiento = MutableStateFlow<String?>(null)
     val errorReconocimiento: StateFlow<String?> = _errorReconocimiento
 
+    fun clearDestinoError() {
+        _errorDestino.value = null
+    }
+
+    fun clearReconocimientoError() {
+        _errorReconocimiento.value = null
+    }
+
     private val _cargandoRegistro = MutableStateFlow(false)
     val cargandoRegistro: StateFlow<Boolean> = _cargandoRegistro
 


### PR DESCRIPTION
## Summary
- add common `HomeConfigNavBar` component
- display navigation bar in module screens
- show Snackbar messages instead of red text
- clear errors from view models
- expose login state reset

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6850da774e64832f8da90ddaad9beffd