### PR TITLE
Fix missing navigation parameter and closing brace

### DIFF
--- a/app/src/main/java/com/example/bitacoradigital/navigation/NavGraph.kt
+++ b/app/src/main/java/com/example/bitacoradigital/navigation/NavGraph.kt
@@ -142,7 +142,8 @@ fun AppNavGraph(
             val perimetroId = homeViewModel.perimetroSeleccionado.value?.perimetroId ?: return@composable
             PerimetrosScreen(
                 perimetroId = perimetroId,
-                permisos = homeViewModel.perimetroSeleccionado.value?.modulos?.get("Perímetro") ?: emptyList()
+                permisos = homeViewModel.perimetroSeleccionado.value?.modulos?.get("Perímetro") ?: emptyList(),
+                navController = navController
             )
         }
 

--- a/app/src/main/java/com/example/bitacoradigital/ui/screens/VisitasScreen.kt
+++ b/app/src/main/java/com/example/bitacoradigital/ui/screens/VisitasScreen.kt
@@ -70,6 +70,7 @@ fun VisitasScreen(
     }
 }
 
+}
 
 @Composable
 fun PermisoCard(


### PR DESCRIPTION
## Summary
- fix missing closing brace in `VisitasScreen`
- pass `navController` to `PerimetrosScreen` in `NavGraph`

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6850e541297c832f871703d1ac1471d5