### PR TITLE
Fix unmatched brace in PerimetrosScreen

### DIFF
--- a/app/src/main/java/com/example/bitacoradigital/ui/screens/perimetro/PerimetrosScreen.kt
+++ b/app/src/main/java/com/example/bitacoradigital/ui/screens/perimetro/PerimetrosScreen.kt
@@ -155,6 +155,7 @@ fun PerimetrosScreen(perimetroId: Int, permisos: List<String>, navController: Na
         }
     }
 }
+}
 
 @Composable
 fun JerarquiaConAcciones(


### PR DESCRIPTION
## Summary
- add missing closing brace in `PerimetrosScreen.kt`

## Testing
- `./gradlew assembleDebug -x lint` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6850e730e9f4832fa5a1677c7404f7b0