### PR TITLE
Apply brand color scheme

### DIFF
--- a/app/src/main/java/com/example/bitacoradigital/ui/components/HomeConfigNavBar.kt
+++ b/app/src/main/java/com/example/bitacoradigital/ui/components/HomeConfigNavBar.kt
@@ -5,7 +5,9 @@ import androidx.compose.material.icons.filled.Home
 import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material3.NavigationBar
 import androidx.compose.material3.NavigationBarItem
+import androidx.compose.material3.NavigationBarItemDefaults
 import androidx.compose.material3.Text
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 
 @Composable
@@ -14,18 +16,35 @@ fun HomeConfigNavBar(
     onHomeClick: () -> Unit,
     onConfigClick: () -> Unit
 ) {
-    NavigationBar {
+    NavigationBar(
+        containerColor = MaterialTheme.colorScheme.primary,
+        contentColor = MaterialTheme.colorScheme.onPrimary
+    ) {
         NavigationBarItem(
             selected = current == "home",
             onClick = onHomeClick,
             icon = { androidx.compose.material3.Icon(Icons.Default.Home, contentDescription = "Home") },
-            label = { Text("Home") }
+            label = { Text("Home") },
+            colors = NavigationBarItemDefaults.colors(
+                selectedIconColor = MaterialTheme.colorScheme.onPrimary,
+                selectedTextColor = MaterialTheme.colorScheme.onPrimary,
+                unselectedIconColor = MaterialTheme.colorScheme.onPrimary.copy(alpha = 0.7f),
+                unselectedTextColor = MaterialTheme.colorScheme.onPrimary.copy(alpha = 0.7f),
+                indicatorColor = MaterialTheme.colorScheme.primary
+            )
         )
         NavigationBarItem(
             selected = current == "config",
             onClick = onConfigClick,
             icon = { androidx.compose.material3.Icon(Icons.Default.Settings, contentDescription = "Configuración") },
-            label = { Text("Configuración") }
+            label = { Text("Configuración") },
+            colors = NavigationBarItemDefaults.colors(
+                selectedIconColor = MaterialTheme.colorScheme.onPrimary,
+                selectedTextColor = MaterialTheme.colorScheme.onPrimary,
+                unselectedIconColor = MaterialTheme.colorScheme.onPrimary.copy(alpha = 0.7f),
+                unselectedTextColor = MaterialTheme.colorScheme.onPrimary.copy(alpha = 0.7f),
+                indicatorColor = MaterialTheme.colorScheme.primary
+            )
         )
     }
 }

--- a/app/src/main/java/com/example/bitacoradigital/ui/screens/VisitasScreen.kt
+++ b/app/src/main/java/com/example/bitacoradigital/ui/screens/VisitasScreen.kt
@@ -53,7 +53,7 @@ fun VisitasScreen(
                 icon = Icons.Default.PersonAdd,
                 titulo = "Registrar Visitas",
                 descripcion = "Captura datos completos de visitantes, proveedores o delivery.",
-                color = Color(0xFF2979FF),
+                color = MaterialTheme.colorScheme.primary,
                 onClick = { navController.navigate("visitas/manual") }
             )
         }
@@ -63,7 +63,7 @@ fun VisitasScreen(
                 icon = Icons.Default.QrCodeScanner,
                 titulo = "Registro por QR",
                 descripcion = "Escanea códigos QR de acceso rápido con verificación automática.",
-                color = Color(0xFF00C853),
+                color = MaterialTheme.colorScheme.primary,
                 onClick = { navController.navigate("visitas/qr") }
             )
         }
@@ -100,17 +100,17 @@ fun PermisoCard(
                 Box(
                     modifier = Modifier
                         .size(40.dp)
-                        .background(Color.White.copy(alpha = 0.2f), shape = RoundedCornerShape(50)),
+                        .background(MaterialTheme.colorScheme.onPrimary.copy(alpha = 0.2f), shape = RoundedCornerShape(50)),
                     contentAlignment = Alignment.Center
                 ) {
-                    Icon(icon, contentDescription = null, tint = Color.White)
+                    Icon(icon, contentDescription = null, tint = MaterialTheme.colorScheme.onPrimary)
                 }
 
                 Spacer(modifier = Modifier.width(8.dp))
 
                 Text(
                     text = "ACTIVO",
-                    color = Color.White,
+                    color = MaterialTheme.colorScheme.onPrimary,
                     fontWeight = FontWeight.Bold,
                     fontSize = 13.sp
                 )
@@ -119,7 +119,7 @@ fun PermisoCard(
             Column {
                 Text(
                     titulo,
-                    color = Color.White,
+                    color = MaterialTheme.colorScheme.onPrimary,
                     fontSize = 20.sp,
                     fontWeight = FontWeight.Bold
                 )
@@ -128,7 +128,7 @@ fun PermisoCard(
 
                 Text(
                     descripcion,
-                    color = Color.White.copy(alpha = 0.9f),
+                    color = MaterialTheme.colorScheme.onPrimary.copy(alpha = 0.9f),
                     fontSize = 13.sp
                 )
 
@@ -136,7 +136,7 @@ fun PermisoCard(
 
                 Text(
                     "\u2022  Toca para acceder",
-                    color = Color.White.copy(alpha = 0.8f),
+                    color = MaterialTheme.colorScheme.onPrimary.copy(alpha = 0.8f),
                     fontSize = 11.sp
                 )
             }

--- a/app/src/main/java/com/example/bitacoradigital/ui/screens/qr/CodigosQRScreen.kt
+++ b/app/src/main/java/com/example/bitacoradigital/ui/screens/qr/CodigosQRScreen.kt
@@ -65,7 +65,7 @@ private fun PermisoCard(titulo: String, descripcion: String, onClick: () -> Unit
             .height(170.dp)
             .clickable { onClick() },
         shape = RoundedCornerShape(20.dp),
-        colors = CardDefaults.cardColors(containerColor = Color(0xFF2979FF)),
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.primary),
         elevation = CardDefaults.cardElevation(defaultElevation = 6.dp)
     ) {
         Column(
@@ -74,8 +74,8 @@ private fun PermisoCard(titulo: String, descripcion: String, onClick: () -> Unit
                 .padding(20.dp),
             verticalArrangement = Arrangement.SpaceBetween
         ) {
-            Text(titulo, color = Color.White, style = MaterialTheme.typography.titleLarge)
-            Text(descripcion, color = Color.White.copy(alpha = 0.9f))
+            Text(titulo, color = MaterialTheme.colorScheme.onPrimary, style = MaterialTheme.typography.titleLarge)
+            Text(descripcion, color = MaterialTheme.colorScheme.onPrimary.copy(alpha = 0.9f))
         }
     }
 }


### PR DESCRIPTION
## Summary
- use brand colors for navigation bar icons and text
- update QR and Visitas screens to honor brand palette

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6850f5494d44832f9dcc008510ce9657