### PR TITLE
Fix missing dashboard navigation

### DIFF
--- a/app/src/main/java/com/example/bitacoradigital/navigation/NavGraph.kt
+++ b/app/src/main/java/com/example/bitacoradigital/navigation/NavGraph.kt
@@ -23,6 +23,7 @@ import com.example.bitacoradigital.ui.screens.RegistroQRScreen
 import com.example.bitacoradigital.ui.screens.perimetro.PerimetrosScreen
 import com.example.bitacoradigital.ui.screens.qr.CodigosQRScreen
 import com.example.bitacoradigital.ui.screens.qr.GenerarCodigoQRScreen
+import com.example.bitacoradigital.ui.screens.dashboard.DashboardScreen
 import com.example.bitacoradigital.viewmodel.HomeViewModel
 import com.example.bitacoradigital.viewmodel.LoginViewModel
 import com.example.bitacoradigital.viewmodel.SessionViewModel
@@ -154,6 +155,10 @@ fun AppNavGraph(
                 onConfiguracionClick = { navController.navigate("configuracion") },
                 navController = navController
             )
+        }
+
+        composable("dashboard") {
+            DashboardScreen(navController = navController)
         }
 
 


### PR DESCRIPTION
## Summary
- import `DashboardScreen`
- add a `dashboard` composable destination

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6850fe406a68832fbebacd30b5225fd6