### PR TITLE
Add phone number verification to signup flow

### DIFF
--- a/app/src/main/java/com/example/bitacoradigital/model/SignupRequest.kt
+++ b/app/src/main/java/com/example/bitacoradigital/model/SignupRequest.kt
@@ -6,5 +6,6 @@ data class SignupRequest(
     val nombre: String,
     val apellidoPaterno: String,
     val apellidoMaterno: String,
-    val nombreInstancia: String
+    val nombreInstancia: String,
+    val telefono: String
 )

--- a/app/src/main/java/com/example/bitacoradigital/ui/screens/auth/SignupScreen.kt
+++ b/app/src/main/java/com/example/bitacoradigital/ui/screens/auth/SignupScreen.kt
@@ -30,6 +30,7 @@ fun SignupScreen(
 ) {
     var email by remember { mutableStateOf("") }
     var password by remember { mutableStateOf("") }
+    var telefono by remember { mutableStateOf("") }
     var nombre by remember { mutableStateOf("") }
     var apellidoPaterno by remember { mutableStateOf("") }
     var apellidoMaterno by remember { mutableStateOf("") }
@@ -70,6 +71,15 @@ fun SignupScreen(
                 }
             },
             keyboardOptions = KeyboardOptions.Default.copy(keyboardType = KeyboardType.Password),
+            modifier = Modifier.fillMaxWidth()
+        )
+
+        OutlinedTextField(
+            value = telefono,
+            onValueChange = { telefono = it },
+            label = { Text("Número de teléfono") },
+            keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Phone),
+            singleLine = true,
             modifier = Modifier.fillMaxWidth()
         )
 
@@ -115,7 +125,8 @@ fun SignupScreen(
                     nombre = nombre,
                     apellidoPaterno = apellidoPaterno,
                     apellidoMaterno = apellidoMaterno,
-                    nombreInstancia = instancia
+                    nombreInstancia = instancia,
+                    telefono = telefono
                 )
                 signupViewModel.signup(req, sessionViewModel, onAwaitCode)
             },

--- a/app/src/main/java/com/example/bitacoradigital/viewmodel/SignupViewModel.kt
+++ b/app/src/main/java/com/example/bitacoradigital/viewmodel/SignupViewModel.kt
@@ -5,11 +5,17 @@ import androidx.lifecycle.viewModelScope
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.setValue
+import android.util.Log
 import com.example.bitacoradigital.model.SignupRequest
 import com.example.bitacoradigital.model.SignupResponse
 import com.example.bitacoradigital.model.VerifyEmailRequest
 import com.example.bitacoradigital.network.RetrofitInstance
 import com.google.gson.Gson
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.RequestBody.Companion.toRequestBody
+import org.json.JSONObject
 
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.Dispatchers
@@ -22,6 +28,29 @@ class SignupViewModel : ViewModel() {
     var loading by mutableStateOf(false)
         private set
 
+    private suspend fun verificarNumeroWhatsApp(numero: String): Boolean = withContext(Dispatchers.IO) {
+        try {
+            val json = JSONObject().apply { put("number", numero) }
+            val body = json.toString().toRequestBody("application/json".toMediaType())
+            val request = Request.Builder()
+                .url("https://bit.cs3.mx/v1/whatsapp/exist/number")
+                .post(body)
+                .addHeader("Content-Type", "application/json")
+                .build()
+            val client = OkHttpClient()
+            val response = client.newCall(request).execute()
+            if (response.isSuccessful) {
+                val res = JSONObject(response.body?.string() ?: "{}")
+                res.optBoolean("exist", false)
+            } else {
+                false
+            }
+        } catch (e: Exception) {
+            Log.e("Signup", "Error verificando numero", e)
+            false
+        }
+    }
+
     fun signup(
         request: SignupRequest,
         sessionViewModel: SessionViewModel,
@@ -30,6 +59,12 @@ class SignupViewModel : ViewModel() {
         viewModelScope.launch {
             loading = true
             try {
+                val valido = verificarNumeroWhatsApp(request.telefono)
+                if (!valido) {
+                    signupState = "Número inválido o no verificado en WhatsApp"
+                    return@launch
+                }
+
                 val response = withContext(Dispatchers.IO) {
                     RetrofitInstance.authApi.signup(request)
                 }


### PR DESCRIPTION
## Summary
- extend `SignupRequest` with `telefono`
- update Signup screen to request and send phone number
- verify phone number before signup using WhatsApp endpoint

## Testing
- `./gradlew test --no-daemon` *(fails: 503 Service Unavailable while downloading Gradle)*

------
https://chatgpt.com/codex/tasks/task_e_6851c42bc05c832f9f3734f59d68e20e