### PR TITLE
Store persona_id for QR generation

### DIFF
--- a/app/src/main/java/com/example/bitacoradigital/data/SessionPreferences.kt
+++ b/app/src/main/java/com/example/bitacoradigital/data/SessionPreferences.kt
@@ -11,6 +11,7 @@ private val Context.dataStore by preferencesDataStore(name = "bitacora_session")
 object SessionKeys {
     val SESSION_TOKEN = stringPreferencesKey("session_token")
     val USER_ID = intPreferencesKey("user_id")
+    val PERSONA_ID = intPreferencesKey("persona_id")
     val FAVORITO_EMPRESA_ID = intPreferencesKey("favorito_empresa_id")
     val FAVORITO_PERIMETRO_ID = intPreferencesKey("favorito_perimetro_id")
     val JSON_SESSION = stringPreferencesKey("json_session") // ✅ nuevo
@@ -20,14 +21,16 @@ class SessionPreferences(private val context: Context) {
 
     val sessionToken: Flow<String?> = context.dataStore.data.map { it[SessionKeys.SESSION_TOKEN] }
     val userId: Flow<Int?> = context.dataStore.data.map { it[SessionKeys.USER_ID] }
+    val personaId: Flow<Int?> = context.dataStore.data.map { it[SessionKeys.PERSONA_ID] }
     val favoritoEmpresaId: Flow<Int?> = context.dataStore.data.map { it[SessionKeys.FAVORITO_EMPRESA_ID] }
     val favoritoPerimetroId: Flow<Int?> = context.dataStore.data.map { it[SessionKeys.FAVORITO_PERIMETRO_ID] }
     val jsonSession: Flow<String?> = context.dataStore.data.map { it[SessionKeys.JSON_SESSION] } // ✅ nuevo
 
-    suspend fun guardarSesion(token: String, userId: Int, json: String) {
+    suspend fun guardarSesion(token: String, userId: Int, personaId: Int, json: String) {
         context.dataStore.edit { prefs ->
             prefs[SessionKeys.SESSION_TOKEN] = token
             prefs[SessionKeys.USER_ID] = userId
+            prefs[SessionKeys.PERSONA_ID] = personaId
             prefs[SessionKeys.JSON_SESSION] = json // ✅ nuevo
         }
     }

--- a/app/src/main/java/com/example/bitacoradigital/model/LoginResponse.kt
+++ b/app/src/main/java/com/example/bitacoradigital/model/LoginResponse.kt
@@ -13,12 +13,14 @@ data class LoginData(
 
 data class User(
     val id: Int,
+    val persona_id: Int,
     val username: String,
     val email: String,
     val display: String,
     val nombre: String?,
     val apellido_paterno: String?,
     val apellido_materno: String?,
+    val telefono: String?,
     val has_usable_password: Boolean,
     val empresas: List<Empresa>
 )

--- a/app/src/main/java/com/example/bitacoradigital/viewmodel/GenerarCodigoQRViewModel.kt
+++ b/app/src/main/java/com/example/bitacoradigital/viewmodel/GenerarCodigoQRViewModel.kt
@@ -30,8 +30,8 @@ class GenerarCodigoQRViewModel(private val prefs: SessionPreferences) : ViewMode
             _mensaje.value = null
             try {
                 val id = withContext(Dispatchers.IO) {
-                    prefs.userId.firstOrNull()
-                } ?: throw Exception("ID de usuario no disponible")
+                    prefs.personaId.firstOrNull()
+                } ?: throw Exception("ID de persona no disponible")
                 val cadDias = caducidad.value.toIntOrNull() ?: 0
                 val json = JSONObject().apply {
                     put("id_invitante", id)

--- a/app/src/main/java/com/example/bitacoradigital/viewmodel/SessionViewModel.kt
+++ b/app/src/main/java/com/example/bitacoradigital/viewmodel/SessionViewModel.kt
@@ -92,7 +92,7 @@ class SessionViewModel(application: Application) : AndroidViewModel(application)
         _usuario.value = user
         val tieneAcceso = user.empresas.any { it.B }
         _tieneAccesoABitacora.value = tieneAcceso
-        prefs.guardarSesion(token, user.id, gson.toJson(user))
+        prefs.guardarSesion(token, user.id, user.persona_id, gson.toJson(user))
     }
 
     fun setTemporalToken(token: String) {


### PR DESCRIPTION
## Summary
- include persona_id and telefono in `User`
- track personaId in `SessionPreferences`
- store personaId when saving sessions
- use personaId for QR invite creation

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_685307ae6804832f904caf29821d42e7