### PR TITLE
Fix perimeter API usage

### DIFF
--- a/app/src/main/java/com/example/bitacoradigital/ui/screens/perimetro/PerimetrosScreen.kt
+++ b/app/src/main/java/com/example/bitacoradigital/ui/screens/perimetro/PerimetrosScreen.kt
@@ -98,12 +98,6 @@ fun PerimetrosScreen(perimetroId: Int, permisos: List<String>, navController: Na
                 }) {
                     Text("Agregar Subzona")
                 }
-                Button(onClick = {
-                    viewModel.crearHermano(nuevoNombre)
-                    nuevoNombre = ""
-                }) {
-                    Text("Agregar Zona")
-                }
             }
         }
 

--- a/app/src/main/java/com/example/bitacoradigital/viewmodel/PerimetroViewModel.kt
+++ b/app/src/main/java/com/example/bitacoradigital/viewmodel/PerimetroViewModel.kt
@@ -70,12 +70,6 @@ class PerimetroViewModel(
         _ruta.update { if (it.isNotEmpty()) it.dropLast(1) else it }
     }
 
-    fun crearHermano(nombre: String) {
-        val padreId = _ruta.value.dropLast(1).lastOrNull()?.perimetro_id
-        val nivel = _ruta.value.lastOrNull()?.nivel ?: return
-        crear(nombre, nivel, padreId)
-    }
-
     fun crearHijo(nombre: String) {
         val actual = _ruta.value.lastOrNull() ?: return
         crear(nombre, actual.nivel + 1, actual.perimetro_id)
@@ -146,7 +140,7 @@ class PerimetroViewModel(
                 val body = json.toString().toRequestBody("application/json".toMediaType())
                 val request = Request.Builder()
                     .url("https://bit.cs3.mx/api/v1/perimetro/${'$'}id/")
-                    .patch(body)
+                    .put(body)
                     .addHeader("x-session-token", token)
                     .addHeader("Content-Type", "application/json")
                     .build()


### PR DESCRIPTION
## Summary
- remove sibling perimeter creation logic from UI and ViewModel
- switch perimeter update call to `PUT`

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68530cde0de4832f835c346ce45b5f77