### PR TITLE
Add Accesos checkpoints management

### DIFF
--- a/app/src/main/java/com/example/bitacoradigital/model/Checkpoint.kt
+++ b/app/src/main/java/com/example/bitacoradigital/model/Checkpoint.kt
@@ -1,0 +1,9 @@
+package com.example.bitacoradigital.model
+
+/** Modelo para un checkpoint de acceso */
+data class Checkpoint(
+    val checkpoint_id: Int,
+    val nombre: String,
+    val tipo: String,
+    val perimetro: Int
+)

--- a/app/src/main/java/com/example/bitacoradigital/navigation/NavGraph.kt
+++ b/app/src/main/java/com/example/bitacoradigital/navigation/NavGraph.kt
@@ -24,6 +24,7 @@ import com.example.bitacoradigital.ui.screens.perimetro.PerimetrosScreen
 import com.example.bitacoradigital.ui.screens.qr.CodigosQRScreen
 import com.example.bitacoradigital.ui.screens.qr.GenerarCodigoQRScreen
 import com.example.bitacoradigital.ui.screens.dashboard.DashboardScreen
+import com.example.bitacoradigital.ui.screens.accesos.AccesosScreen
 import com.example.bitacoradigital.viewmodel.HomeViewModel
 import com.example.bitacoradigital.viewmodel.LoginViewModel
 import com.example.bitacoradigital.viewmodel.SessionViewModel
@@ -144,6 +145,15 @@ fun AppNavGraph(
             PerimetrosScreen(
                 perimetroId = perimetroId,
                 permisos = homeViewModel.perimetroSeleccionado.value?.modulos?.get("Perímetro") ?: emptyList(),
+                navController = navController
+            )
+        }
+
+        composable("accesos") {
+            val perimetroId = homeViewModel.perimetroSeleccionado.value?.perimetroId ?: return@composable
+            AccesosScreen(
+                perimetroId = perimetroId,
+                permisos = homeViewModel.perimetroSeleccionado.value?.modulos?.get("Accesos") ?: emptyList(),
                 navController = navController
             )
         }

--- a/app/src/main/java/com/example/bitacoradigital/ui/components/menu/ModuleButton.kt
+++ b/app/src/main/java/com/example/bitacoradigital/ui/components/menu/ModuleButton.kt
@@ -70,5 +70,6 @@ fun moduloIcon(nombre: String): ImageVector = when (nombre) {
     "Eventos" -> Icons.Default.Event
     "Administración de Usuarios" -> Icons.Default.Group
     "Registros de Visitas" -> Icons.Default.ListAlt
+    "Accesos" -> Icons.Default.DirectionsCar
     else -> Icons.Default.Dashboard
 }

--- a/app/src/main/java/com/example/bitacoradigital/ui/screens/HomeScreen.kt
+++ b/app/src/main/java/com/example/bitacoradigital/ui/screens/HomeScreen.kt
@@ -84,6 +84,7 @@ fun HomeScreen(
                                 "Perímetro" -> navController.navigate("perimetros")
                                 "Códigos QR" -> navController.navigate("qr")
                                 "Dashboard" -> navController.navigate("dashboard")
+                                "Accesos" -> navController.navigate("accesos")
                                 else -> { }
                             }
                         }

--- a/app/src/main/java/com/example/bitacoradigital/ui/screens/accesos/AccesosScreen.kt
+++ b/app/src/main/java/com/example/bitacoradigital/ui/screens/accesos/AccesosScreen.kt
@@ -1,0 +1,136 @@
+package com.example.bitacoradigital.ui.screens.accesos
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.Edit
+import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.viewmodel.compose.viewModel
+import androidx.navigation.NavHostController
+import com.example.bitacoradigital.data.SessionPreferences
+import com.example.bitacoradigital.viewmodel.CheckpointsViewModel
+import com.example.bitacoradigital.viewmodel.CheckpointsViewModelFactory
+import com.example.bitacoradigital.model.Checkpoint
+import com.example.bitacoradigital.ui.components.HomeConfigNavBar
+
+@Composable
+fun AccesosScreen(perimetroId: Int, permisos: List<String>, navController: NavHostController) {
+    val context = LocalContext.current
+    val prefs = remember { SessionPreferences(context) }
+    val viewModel: CheckpointsViewModel = viewModel(factory = CheckpointsViewModelFactory(prefs, perimetroId))
+
+    val checkpoints by viewModel.checkpoints.collectAsState()
+    val cargando by viewModel.cargando.collectAsState()
+    val error by viewModel.error.collectAsState()
+
+    var nuevoNombre by remember { mutableStateOf("") }
+    var nuevoTipo by remember { mutableStateOf("") }
+    var editar by remember { mutableStateOf<Checkpoint?>(null) }
+    var editarNombre by remember { mutableStateOf("") }
+    var editarTipo by remember { mutableStateOf("") }
+
+    val puedeCrear = "Crear Checkpoint" in permisos
+    val puedeEditar = "Editar Checkpoint" in permisos
+    val puedeEliminar = "Eliminar Checkpoint" in permisos
+
+    LaunchedEffect(Unit) { viewModel.cargarCheckpoints() }
+
+    val snackbarHostState = remember { SnackbarHostState() }
+    error?.let { msg ->
+        LaunchedEffect(msg) {
+            snackbarHostState.showSnackbar(msg)
+            viewModel.cargarCheckpoints()
+        }
+    }
+
+    Scaffold(
+        bottomBar = {
+            HomeConfigNavBar(
+                current = "",
+                onHomeClick = { navController.navigate("home") },
+                onConfigClick = { navController.navigate("configuracion") }
+            )
+        },
+        snackbarHost = { SnackbarHost(snackbarHostState) }
+    ) { innerPadding ->
+        Column(Modifier.fillMaxSize().padding(innerPadding).padding(16.dp)) {
+            if (cargando) {
+                CircularProgressIndicator()
+            } else {
+                LazyColumn(Modifier.weight(1f), verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                    items(checkpoints) { cp ->
+                        Card(modifier = Modifier.fillMaxWidth()) {
+                            Row(
+                                Modifier
+                                    .fillMaxWidth()
+                                    .padding(8.dp),
+                                verticalAlignment = Alignment.CenterVertically
+                            ) {
+                                Column(Modifier.weight(1f)) {
+                                    Text(cp.nombre)
+                                    Text(cp.tipo, style = MaterialTheme.typography.bodySmall)
+                                }
+                                if (puedeEditar) {
+                                    IconButton(onClick = { editar = cp; editarNombre = cp.nombre; editarTipo = cp.tipo }) {
+                                        Icon(Icons.Default.Edit, contentDescription = null)
+                                    }
+                                }
+                                if (puedeEliminar) {
+                                    IconButton(onClick = { viewModel.eliminarCheckpoint(cp.checkpoint_id) }) {
+                                        Icon(Icons.Default.Delete, contentDescription = null)
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+                if (puedeCrear) {
+                    Spacer(Modifier.height(16.dp))
+                    OutlinedTextField(
+                        value = nuevoNombre,
+                        onValueChange = { nuevoNombre = it },
+                        label = { Text("Nombre") },
+                        modifier = Modifier.fillMaxWidth()
+                    )
+                    OutlinedTextField(
+                        value = nuevoTipo,
+                        onValueChange = { nuevoTipo = it },
+                        label = { Text("Tipo") },
+                        modifier = Modifier.fillMaxWidth()
+                    )
+                    Spacer(Modifier.height(8.dp))
+                    Button(onClick = { viewModel.crearCheckpoint(nuevoNombre, nuevoTipo); nuevoNombre = ""; nuevoTipo = "" }, modifier = Modifier.fillMaxWidth()) {
+                        Icon(Icons.Default.Add, contentDescription = null)
+                        Spacer(Modifier.width(8.dp))
+                        Text("Agregar Checkpoint")
+                    }
+                }
+            }
+
+            editar?.let { cp ->
+                AlertDialog(
+                    onDismissRequest = { editar = null },
+                    confirmButton = {
+                        TextButton(onClick = { viewModel.actualizarCheckpoint(cp.checkpoint_id, editarNombre, editarTipo); editar = null }) { Text("Guardar") }
+                    },
+                    dismissButton = { TextButton(onClick = { editar = null }) { Text("Cancelar") } },
+                    title = { Text("Editar checkpoint") },
+                    text = {
+                        Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                            OutlinedTextField(value = editarNombre, onValueChange = { editarNombre = it }, label = { Text("Nombre") })
+                            OutlinedTextField(value = editarTipo, onValueChange = { editarTipo = it }, label = { Text("Tipo") })
+                        }
+                    }
+                )
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/example/bitacoradigital/viewmodel/CheckpointsViewModel.kt
+++ b/app/src/main/java/com/example/bitacoradigital/viewmodel/CheckpointsViewModel.kt
@@ -1,0 +1,143 @@
+package com.example.bitacoradigital.viewmodel
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.example.bitacoradigital.data.SessionPreferences
+import com.example.bitacoradigital.model.Checkpoint
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.RequestBody.Companion.toRequestBody
+import org.json.JSONObject
+
+class CheckpointsViewModel(
+    private val prefs: SessionPreferences,
+    private val perimetroId: Int
+) : ViewModel() {
+
+    private val _checkpoints = MutableStateFlow<List<Checkpoint>>(emptyList())
+    val checkpoints: StateFlow<List<Checkpoint>> = _checkpoints.asStateFlow()
+
+    private val _cargando = MutableStateFlow(false)
+    val cargando: StateFlow<Boolean> = _cargando.asStateFlow()
+
+    private val _error = MutableStateFlow<String?>(null)
+    val error: StateFlow<String?> = _error.asStateFlow()
+
+    fun cargarCheckpoints() {
+        viewModelScope.launch {
+            _cargando.value = true
+            _error.value = null
+            try {
+                val token = withContext(Dispatchers.IO) { prefs.sessionToken.first() } ?: return@launch
+                val request = Request.Builder()
+                    .url("https://bit.cs3.mx/api/v1/checkpoints/?perimetro_id=$perimetroId")
+                    .get()
+                    .addHeader("x-session-token", token)
+                    .build()
+                val client = OkHttpClient()
+                val response = withContext(Dispatchers.IO) { client.newCall(request).execute() }
+                if (response.isSuccessful) {
+                    val jsonArr = org.json.JSONArray(response.body?.string() ?: "[]")
+                    val list = mutableListOf<Checkpoint>()
+                    for (i in 0 until jsonArr.length()) {
+                        val obj = jsonArr.getJSONObject(i)
+                        list.add(
+                            Checkpoint(
+                                checkpoint_id = obj.optInt("checkpoint_id"),
+                                nombre = obj.optString("nombre"),
+                                tipo = obj.optString("tipo"),
+                                perimetro = obj.optInt("perimetro")
+                            )
+                        )
+                    }
+                    _checkpoints.value = list
+                } else {
+                    _error.value = "Error ${'$'}{response.code}"
+                }
+            } catch (e: Exception) {
+                _error.value = e.localizedMessage
+            } finally {
+                _cargando.value = false
+            }
+        }
+    }
+
+    fun crearCheckpoint(nombre: String, tipo: String) {
+        viewModelScope.launch {
+            modificar(null, nombre, tipo)
+        }
+    }
+
+    fun actualizarCheckpoint(id: Int, nombre: String, tipo: String) {
+        viewModelScope.launch {
+            modificar(id, nombre, tipo)
+        }
+    }
+
+    fun eliminarCheckpoint(id: Int) {
+        viewModelScope.launch {
+            _cargando.value = true
+            _error.value = null
+            try {
+                val token = withContext(Dispatchers.IO) { prefs.sessionToken.first() } ?: return@launch
+                val request = Request.Builder()
+                    .url("http://192.168.100.8:8001/api/v1/checkpoints/${'$'}id/")
+                    .delete()
+                    .addHeader("x-session-token", token)
+                    .build()
+                val client = OkHttpClient()
+                val response = withContext(Dispatchers.IO) { client.newCall(request).execute() }
+                if (response.isSuccessful) {
+                    cargarCheckpoints()
+                } else {
+                    _error.value = "Error ${'$'}{response.code}"
+                }
+            } catch (e: Exception) {
+                _error.value = e.localizedMessage
+            } finally {
+                _cargando.value = false
+            }
+        }
+    }
+
+    private suspend fun modificar(id: Int?, nombre: String, tipo: String) {
+        _cargando.value = true
+        _error.value = null
+        try {
+            val token = withContext(Dispatchers.IO) { prefs.sessionToken.first() } ?: return
+            val json = JSONObject().apply {
+                put("nombre", nombre)
+                put("tipo", tipo)
+                put("perimetro", perimetroId)
+            }
+            val body = json.toString().toRequestBody("application/json".toMediaType())
+            val builder = Request.Builder()
+                .addHeader("x-session-token", token)
+                .addHeader("Content-Type", "application/json")
+            val request = if (id == null) {
+                builder.url("https://bit.cs3.mx/api/v1/checkpoints").post(body).build()
+            } else {
+                builder.url("https://bit.cs3.mx/api/v1/checkpoints/${'$'}id/").put(body).build()
+            }
+            val client = OkHttpClient()
+            val response = withContext(Dispatchers.IO) { client.newCall(request).execute() }
+            if (response.isSuccessful) {
+                cargarCheckpoints()
+            } else {
+                _error.value = "Error ${'$'}{response.code}"
+            }
+        } catch (e: Exception) {
+            _error.value = e.localizedMessage
+        } finally {
+            _cargando.value = false
+        }
+    }
+}

--- a/app/src/main/java/com/example/bitacoradigital/viewmodel/CheckpointsViewModelFactory.kt
+++ b/app/src/main/java/com/example/bitacoradigital/viewmodel/CheckpointsViewModelFactory.kt
@@ -1,0 +1,18 @@
+package com.example.bitacoradigital.viewmodel
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import com.example.bitacoradigital.data.SessionPreferences
+
+class CheckpointsViewModelFactory(
+    private val prefs: SessionPreferences,
+    private val perimetroId: Int
+) : ViewModelProvider.Factory {
+    override fun <T : ViewModel> create(modelClass: Class<T>): T {
+        if (modelClass.isAssignableFrom(CheckpointsViewModel::class.java)) {
+            @Suppress("UNCHECKED_CAST")
+            return CheckpointsViewModel(prefs, perimetroId) as T
+        }
+        throw IllegalArgumentException("Unknown ViewModel class")
+    }
+}


### PR DESCRIPTION
## Summary
- add `Checkpoint` data model
- create `CheckpointsViewModel` and factory
- implement `AccesosScreen` with list/create/edit UI
- show Accesos module from home screen and navigation graph
- map icon for Accesos module
- allow deleting checkpoints

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68531775cbdc832fad097d6155c9baba