### PR TITLE
Fix perimeter usage in Accesos module

### DIFF
--- a/app/src/main/java/com/example/bitacoradigital/navigation/NavGraph.kt
+++ b/app/src/main/java/com/example/bitacoradigital/navigation/NavGraph.kt
@@ -150,9 +150,8 @@ fun AppNavGraph(
         }
 
         composable("accesos") {
-            val perimetroId = homeViewModel.perimetroSeleccionado.value?.perimetroId ?: return@composable
             AccesosScreen(
-                perimetroId = perimetroId,
+                homeViewModel = homeViewModel,
                 permisos = homeViewModel.perimetroSeleccionado.value?.modulos?.get("Accesos") ?: emptyList(),
                 navController = navController
             )

--- a/app/src/main/java/com/example/bitacoradigital/ui/screens/accesos/AccesosScreen.kt
+++ b/app/src/main/java/com/example/bitacoradigital/ui/screens/accesos/AccesosScreen.kt
@@ -18,11 +18,14 @@ import androidx.navigation.NavHostController
 import com.example.bitacoradigital.data.SessionPreferences
 import com.example.bitacoradigital.viewmodel.CheckpointsViewModel
 import com.example.bitacoradigital.viewmodel.CheckpointsViewModelFactory
+import com.example.bitacoradigital.viewmodel.HomeViewModel
 import com.example.bitacoradigital.model.Checkpoint
 import com.example.bitacoradigital.ui.components.HomeConfigNavBar
 
 @Composable
-fun AccesosScreen(perimetroId: Int, permisos: List<String>, navController: NavHostController) {
+fun AccesosScreen(homeViewModel: HomeViewModel, permisos: List<String>, navController: NavHostController) {
+    val perimetroSeleccionado by homeViewModel.perimetroSeleccionado.collectAsState()
+    val perimetroId = perimetroSeleccionado?.perimetroId ?: return
     val context = LocalContext.current
     val prefs = remember { SessionPreferences(context) }
     val viewModel: CheckpointsViewModel = viewModel(factory = CheckpointsViewModelFactory(prefs, perimetroId))


### PR DESCRIPTION
## Summary
- fetch the currently selected perimeter from `HomeViewModel` inside `AccesosScreen`
- update navigation to pass `HomeViewModel` instead of a static perimeter id

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853205ea32c832fb656a8246f017042