### PR TITLE
Improve document scan UI

### DIFF
--- a/app/src/main/java/com/example/bitacoradigital/ui/screens/registrovisita/PasoDocumento.kt
+++ b/app/src/main/java/com/example/bitacoradigital/ui/screens/registrovisita/PasoDocumento.kt
@@ -9,16 +9,23 @@ import com.example.bitacoradigital.util.Constants
 import androidx.core.content.ContextCompat
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.fadeIn
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.CameraAlt
+import androidx.compose.material.icons.filled.Error
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
-import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.asImageBitmap
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.graphics.Color
 import coil.compose.rememberAsyncImagePainter
 import java.io.File
 import com.example.bitacoradigital.viewmodel.RegistroVisitaViewModel
@@ -71,70 +78,114 @@ fun PasoDocumento(viewModel: RegistroVisitaViewModel) {
     }
 
     Box(Modifier.fillMaxSize()) {
-    Column(modifier = Modifier.padding(16.dp)) {
-        Text("Paso 2: Escanea tu documento", style = MaterialTheme.typography.titleLarge)
-        Spacer(modifier = Modifier.height(16.dp))
-
-        Button(onClick = {
-            if (hasCameraPermission) {
-                val uriTemp = createImageUri(context)
-                tempUri = uriTemp
-                launcher.launch(uriTemp)
-            } else {
-                permissionLauncher.launch(Manifest.permission.CAMERA)
-            }
-        }) {
-            Text("Tomar Foto")
-        }
-
-        if (!hasCameraPermission) {
-            Spacer(modifier = Modifier.height(8.dp))
-            Text(
-                text = "Se requiere permiso de cámara para tomar fotos",
-                color = MaterialTheme.colorScheme.error
-            )
-        }
-
-        Spacer(modifier = Modifier.height(16.dp))
-
-        uri?.let {
-            val painter = rememberAsyncImagePainter(model = it)
-            Image(
-                painter = painter,
-                contentDescription = null,
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .height(200.dp),
-                contentScale = ContentScale.Crop
-            )
-        }
-
-        Spacer(modifier = Modifier.height(16.dp))
-
-        Button(
-            onClick = {
-                coroutineScope.launch {
-                    viewModel.reconocerDocumento(context)
-                    viewModel.avanzarPaso()
-                }
-            },
-            enabled = uri != null && !cargando
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(24.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.Center
         ) {
-            Text(if (cargando) "Procesando..." else "Continuar")
-        }
+            Text(
+                "Paso 2: Escanea tu documento",
+                style = MaterialTheme.typography.titleLarge
+            )
 
-        error?.let { msg ->
-            LaunchedEffect(msg) {
-                snackbarHostState.showSnackbar(msg)
-                viewModel.clearReconocimientoError()
+            Spacer(modifier = Modifier.height(24.dp))
+
+            Text(
+                text = "Toca para escanear tu identificación",
+                style = MaterialTheme.typography.bodyLarge
+            )
+
+            Spacer(modifier = Modifier.height(16.dp))
+
+            Button(
+                onClick = {
+                    if (hasCameraPermission) {
+                        val uriTemp = createImageUri(context)
+                        tempUri = uriTemp
+                        launcher.launch(uriTemp)
+                    } else {
+                        permissionLauncher.launch(Manifest.permission.CAMERA)
+                    }
+                },
+                colors = ButtonDefaults.buttonColors(
+                    containerColor = Color(0xFFD65930),
+                    contentColor = Color.White
+                )
+            ) {
+                Icon(Icons.Default.CameraAlt, contentDescription = null)
+                Spacer(Modifier.width(8.dp))
+                Text("Tomar Foto", style = MaterialTheme.typography.bodyLarge)
+            }
+
+            if (!hasCameraPermission) {
+                Spacer(modifier = Modifier.height(16.dp))
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    Icon(
+                        Icons.Default.Error,
+                        contentDescription = null,
+                        tint = MaterialTheme.colorScheme.error
+                    )
+                    Spacer(Modifier.width(4.dp))
+                    Text(
+                        text = "Se requiere permiso de cámara",
+                        color = MaterialTheme.colorScheme.error,
+                        style = MaterialTheme.typography.bodyMedium
+                    )
+                }
+            }
+
+            AnimatedVisibility(visible = uri != null, enter = fadeIn()) {
+                Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                    Spacer(modifier = Modifier.height(24.dp))
+                    uri?.let { selected ->
+                        val painter = rememberAsyncImagePainter(model = selected)
+                        Image(
+                            painter = painter,
+                            contentDescription = null,
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .height(200.dp)
+                                .clip(RoundedCornerShape(12.dp)),
+                            contentScale = ContentScale.Crop
+                        )
+                    }
+
+                    Spacer(modifier = Modifier.height(24.dp))
+
+                    Button(
+                        onClick = {
+                            coroutineScope.launch {
+                                viewModel.reconocerDocumento(context)
+                                viewModel.avanzarPaso()
+                            }
+                        },
+                        enabled = uri != null && !cargando
+                    ) {
+                        Text(
+                            if (cargando) "Procesando..." else "Continuar",
+                            style = MaterialTheme.typography.bodyLarge
+                        )
+                    }
+
+                    if (cargando) {
+                        Spacer(modifier = Modifier.height(16.dp))
+                        CircularProgressIndicator()
+                    }
+                }
+            }
+
+            error?.let { msg ->
+                LaunchedEffect(msg) {
+                    snackbarHostState.showSnackbar(msg)
+                    viewModel.clearReconocimientoError()
+                }
             }
         }
-
-        if (cargando) {
-            Spacer(modifier = Modifier.height(16.dp))
-            CircularProgressIndicator()
-        }
-    }
-    SnackbarHost(hostState = snackbarHostState, modifier = Modifier.align(Alignment.BottomCenter))
+        SnackbarHost(
+            hostState = snackbarHostState,
+            modifier = Modifier.align(Alignment.BottomCenter)
+        )
     }
 }


### PR DESCRIPTION
## Summary
- enhance PasoDocumento screen with better visuals
- add camera icon button and fade-in animations
- hide Continue button until a photo is taken
- show camera permission error with icon

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853998ebc84832fa6d05957a4e20f44