### PR TITLE
Fix Perimetros scrolling

### DIFF
--- a/app/src/main/java/com/example/bitacoradigital/ui/screens/perimetro/PerimetrosScreen.kt
+++ b/app/src/main/java/com/example/bitacoradigital/ui/screens/perimetro/PerimetrosScreen.kt
@@ -3,7 +3,8 @@ package com.example.bitacoradigital.ui.screens.perimetro
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.foundation.layout.*
-import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.animation.animateContentSize
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.ui.draw.rotate
@@ -159,7 +160,11 @@ fun JerarquiaConAcciones(
 ) {
     val nodoActual = ruta.lastOrNull() ?: return
 
-    Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+    val scrollState = rememberScrollState()
+    Column(
+        verticalArrangement = Arrangement.spacedBy(8.dp),
+        modifier = Modifier.verticalScroll(scrollState)
+    ) {
         Row(verticalAlignment = Alignment.CenterVertically) {
             ruta.forEachIndexed { index, nodo ->
                 val esActual = index == ruta.lastIndex


### PR DESCRIPTION
## Summary
- enable vertical scrolling for the hierarchy card on the Perimetros screen

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855dfd01f04832fbcdeff0ded0d08ff