### PR TITLE
Add manual phone override and share QR

### DIFF
--- a/app/src/main/java/com/example/bitacoradigital/ui/screens/registrovisita/PasoConfirmacion.kt
+++ b/app/src/main/java/com/example/bitacoradigital/ui/screens/registrovisita/PasoConfirmacion.kt
@@ -22,6 +22,7 @@ import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.unit.dp
 import coil.compose.AsyncImage
+import androidx.compose.ui.platform.LocalContext
 
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
@@ -93,9 +94,10 @@ fun PasoConfirmacion(viewModel: RegistroVisitaViewModel) {
 
         Spacer(Modifier.height(24.dp))
 
+        val context = LocalContext.current
         Button(
             onClick = {
-                viewModel.registrarVisita()
+                viewModel.registrarVisita(context)
                 viewModel.avanzarPaso()
             },
             modifier = Modifier.fillMaxWidth()

--- a/app/src/main/java/com/example/bitacoradigital/ui/screens/registrovisita/PasoFinal.kt
+++ b/app/src/main/java/com/example/bitacoradigital/ui/screens/registrovisita/PasoFinal.kt
@@ -2,17 +2,26 @@
 package com.example.bitacoradigital.ui.screens.registrovisita
 
 import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.Image
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.asImageBitmap
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import android.content.Intent
+import androidx.core.content.FileProvider
+import java.io.File
+import com.example.bitacoradigital.util.Constants
 import com.example.bitacoradigital.viewmodel.RegistroVisitaViewModel
 
 @Composable
 fun PasoFinal(viewModel: RegistroVisitaViewModel) {
     val respuesta by viewModel.respuestaRegistro.collectAsState()
+    val qrBitmap by viewModel.qrBitmap.collectAsState()
+    val context = LocalContext.current
     Column(
         modifier = Modifier
             .fillMaxSize()
@@ -34,6 +43,24 @@ fun PasoFinal(viewModel: RegistroVisitaViewModel) {
 
         respuesta?.let {
             Text(it, fontSize = 20.sp)
+        }
+
+        qrBitmap?.let { bmp ->
+            Spacer(modifier = Modifier.height(16.dp))
+            Image(bitmap = bmp.asImageBitmap(), contentDescription = null, modifier = Modifier.size(200.dp))
+            Spacer(modifier = Modifier.height(8.dp))
+            Button(onClick = {
+                val file = File(context.cacheDir, "qr_share.jpg")
+                file.outputStream().use { bmp.compress(android.graphics.Bitmap.CompressFormat.JPEG, 100, it) }
+                val uri = FileProvider.getUriForFile(context, Constants.FILE_PROVIDER_AUTHORITY, file)
+                val intent = Intent(Intent.ACTION_SEND).apply {
+                    type = "image/jpeg"
+                    putExtra(Intent.EXTRA_STREAM, uri)
+                }
+                context.startActivity(Intent.createChooser(intent, "Compartir manualmente"))
+            }) {
+                Text("Compartir manualmente")
+            }
         }
 
         Spacer(modifier = Modifier.height(32.dp))

--- a/app/src/main/java/com/example/bitacoradigital/ui/screens/registrovisita/PasoTelefono.kt
+++ b/app/src/main/java/com/example/bitacoradigital/ui/screens/registrovisita/PasoTelefono.kt
@@ -19,6 +19,7 @@ fun PasoTelefono(viewModel: RegistroVisitaViewModel) {
 
     var cargando by remember { mutableStateOf(false) }
     var mensajeError by remember { mutableStateOf<String?>(null) }
+    var verificacionFallida by remember { mutableStateOf(false) }
     val snackbarHostState = remember { SnackbarHostState() }
 
     val coroutineScope = rememberCoroutineScope()
@@ -52,6 +53,7 @@ fun PasoTelefono(viewModel: RegistroVisitaViewModel) {
                     mensajeError = null
 
                     coroutineScope.launch {
+                        verificacionFallida = false
                         val existe = viewModel.verificarNumeroWhatsApp(telefono)
                         cargando = false
                         if (existe) {
@@ -59,6 +61,7 @@ fun PasoTelefono(viewModel: RegistroVisitaViewModel) {
                             viewModel.avanzarPaso()
                         } else {
                             mensajeError = "Número inválido o no verificado en WhatsApp"
+                            verificacionFallida = true
                         }
                     }
                 },
@@ -66,8 +69,17 @@ fun PasoTelefono(viewModel: RegistroVisitaViewModel) {
                 modifier = Modifier
                     .fillMaxWidth()
                     .shadow(4.dp, shape = MaterialTheme.shapes.medium)
-            ) {
+            ) { 
                 Text(if (cargando) "Verificando..." else "Verificar número")
+            }
+            if (verificacionFallida) {
+                Spacer(modifier = Modifier.height(8.dp))
+                Button(
+                    onClick = { viewModel.avanzarPaso() },
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .shadow(4.dp, shape = MaterialTheme.shapes.medium)
+                ) { Text("Continuar de todos modos") }
             }
         } else {
             Text("✅ Número verificado", color = MaterialTheme.colorScheme.primary)


### PR DESCRIPTION
## Summary
- allow continuing when WhatsApp check fails
- send document image to QR endpoint when finishing registration
- display generated QR and allow sharing from Android
- pass context to registration call

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855e73cb9b4832fae5e864f336ebf9f