### PR TITLE
Ensure final screen waits for QR response

### DIFF
--- a/app/src/main/java/com/example/bitacoradigital/ui/screens/registrovisita/PasoConfirmacion.kt
+++ b/app/src/main/java/com/example/bitacoradigital/ui/screens/registrovisita/PasoConfirmacion.kt
@@ -40,6 +40,13 @@ fun PasoConfirmacion(viewModel: RegistroVisitaViewModel) {
     val fotos by viewModel.fotosAdicionales.collectAsState()
 
     val cargando by viewModel.cargandoRegistro.collectAsState()
+    val registroCompleto by viewModel.registroCompleto.collectAsState()
+
+    LaunchedEffect(registroCompleto) {
+        if (registroCompleto) {
+            viewModel.avanzarPaso()
+        }
+    }
 
     Box(Modifier.fillMaxSize()) {
         Column(modifier = Modifier
@@ -98,7 +105,6 @@ fun PasoConfirmacion(viewModel: RegistroVisitaViewModel) {
         Button(
             onClick = {
                 viewModel.registrarVisita(context)
-                viewModel.avanzarPaso()
             },
             modifier = Modifier.fillMaxWidth()
         ) {

--- a/app/src/main/java/com/example/bitacoradigital/viewmodel/RegistroVisitaViewModel.kt
+++ b/app/src/main/java/com/example/bitacoradigital/viewmodel/RegistroVisitaViewModel.kt
@@ -294,7 +294,14 @@ class RegistroVisitaViewModel(
                     .addHeader("Content-Type", "application/json")
                     .build()
 
-                val client = OkHttpClient()
+                // The QR generation service can take a long time to respond so we
+                // disable all timeouts on the client used for this request.
+                val client = OkHttpClient.Builder()
+                    .connectTimeout(0, TimeUnit.MILLISECONDS)
+                    .readTimeout(0, TimeUnit.MILLISECONDS)
+                    .writeTimeout(0, TimeUnit.MILLISECONDS)
+                    .callTimeout(0, TimeUnit.MILLISECONDS)
+                    .build()
                 val response = withContext(Dispatchers.IO) {
                     client.newCall(request).execute()
                 }


### PR DESCRIPTION
## Summary
- wait for the QR response in `PasoConfirmacion` before navigating
- disable timeouts when calling the QR service

## Testing
- `./gradlew tasks --all`
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855ebd50df4832f8d35567a99936503