### PR TITLE
Remove QR request timeout only

### DIFF
--- a/app/src/main/java/com/example/bitacoradigital/viewmodel/RegistroVisitaViewModel.kt
+++ b/app/src/main/java/com/example/bitacoradigital/viewmodel/RegistroVisitaViewModel.kt
@@ -294,14 +294,7 @@ class RegistroVisitaViewModel(
                     .addHeader("Content-Type", "application/json")
                     .build()
 
-                // The QR generation service can take a long time to respond so we
-                // disable all timeouts on the client used for this request.
-                val client = OkHttpClient.Builder()
-                    .connectTimeout(0, TimeUnit.MILLISECONDS)
-                    .readTimeout(0, TimeUnit.MILLISECONDS)
-                    .writeTimeout(0, TimeUnit.MILLISECONDS)
-                    .callTimeout(0, TimeUnit.MILLISECONDS)
-                    .build()
+                val client = OkHttpClient()
                 val response = withContext(Dispatchers.IO) {
                     client.newCall(request).execute()
                 }
@@ -334,7 +327,13 @@ class RegistroVisitaViewModel(
                                     .url("http://qr.cs3.mx/bite/enviar-qr-id-ws/")
                                     .post(req)
                                     .build()
-                                val qrResp = withContext(Dispatchers.IO) { client.newCall(qrRequest).execute() }
+                                val qrClient = OkHttpClient.Builder()
+                                    .connectTimeout(0, TimeUnit.MILLISECONDS)
+                                    .readTimeout(0, TimeUnit.MILLISECONDS)
+                                    .writeTimeout(0, TimeUnit.MILLISECONDS)
+                                    .callTimeout(0, TimeUnit.MILLISECONDS)
+                                    .build()
+                                val qrResp = withContext(Dispatchers.IO) { qrClient.newCall(qrRequest).execute() }
                                 if (qrResp.isSuccessful) {
                                     val qStr = qrResp.body?.string()
                                     val qJson = JSONObject(qStr ?: "{}")


### PR DESCRIPTION
## Summary
- use default OkHttpClient for registro-visita request
- create a separate client without timeouts for the QR service

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855f1d9cd58832fa1306b5037e586cc