### PR TITLE
Fix NetworkOnMainThread issue in ViewModels

### DIFF
--- a/app/src/main/java/com/example/bitacoradigital/viewmodel/CheckpointsViewModel.kt
+++ b/app/src/main/java/com/example/bitacoradigital/viewmodel/CheckpointsViewModel.kt
@@ -46,7 +46,8 @@ class CheckpointsViewModel(
                 val response = withContext(Dispatchers.IO) { client.newCall(request).execute() }
                 response.use { resp ->
                     if (resp.isSuccessful) {
-                        val jsonArr = org.json.JSONArray(resp.body?.string() ?: "[]")
+                        val jsonStr = withContext(Dispatchers.IO) { resp.body?.string() }
+                        val jsonArr = org.json.JSONArray(jsonStr ?: "[]")
                         val list = mutableListOf<Checkpoint>()
                         for (i in 0 until jsonArr.length()) {
                             val obj = jsonArr.getJSONObject(i)

--- a/app/src/main/java/com/example/bitacoradigital/viewmodel/RegistroVisitaViewModel.kt
+++ b/app/src/main/java/com/example/bitacoradigital/viewmodel/RegistroVisitaViewModel.kt
@@ -246,7 +246,8 @@ class RegistroVisitaViewModel(
             val response = withContext(Dispatchers.IO) { client.newCall(request).execute() }
             response.use { resp ->
                 if (resp.isSuccessful) {
-                    val json = org.json.JSONObject(resp.body?.string() ?: "{}")
+                    val jsonStr = withContext(Dispatchers.IO) { resp.body?.string() }
+                    val json = org.json.JSONObject(jsonStr ?: "{}")
                     nombre.value = json.optString("nombre")
                     apellidoPaterno.value = json.optString("paterno")
                     apellidoMaterno.value = json.optString("materno")
@@ -304,7 +305,7 @@ class RegistroVisitaViewModel(
 
                 response.use { resp ->
                     if (resp.isSuccessful) {
-                        val bodyStr = resp.body?.string()
+                        val bodyStr = withContext(Dispatchers.IO) { resp.body?.string() }
                         Log.d("RegistroVisita", "Registro exitoso: $bodyStr")
 
                         // Enviar QR y whatsapp
@@ -340,7 +341,7 @@ class RegistroVisitaViewModel(
                                     val qrResp = withContext(Dispatchers.IO) { qrClient.newCall(qrRequest).execute() }
                                     qrResp.use { qrR ->
                                         if (qrR.isSuccessful) {
-                                            val qStr = qrR.body?.string()
+                                            val qStr = withContext(Dispatchers.IO) { qrR.body?.string() }
                                             val qJson = JSONObject(qStr ?: "{}")
                                             qrMsg = qJson.optString("mensaje")
                                             val imgBase = qJson.optString("imagen_binaria")
@@ -358,7 +359,7 @@ class RegistroVisitaViewModel(
                         qrBitmap.value = qrImg
                         registroCompleto.value = true
                     } else {
-                        val errorBody = resp.body?.string()
+                        val errorBody = withContext(Dispatchers.IO) { resp.body?.string() }
                         Log.e("RegistroVisita", "Error en el registro: $errorBody")
                         _errorDestino.value = "Registro fallido: ${resp.code}"
                     }


### PR DESCRIPTION
## Summary
- handle all network response reads in `Dispatchers.IO`
- avoid `NetworkOnMainThreadException` when registering visits or loading checkpoints

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68563343e268832f9fb68ca9c471bb12