### PR TITLE
Fix FileProvider path for QR sharing

### DIFF
--- a/app/src/main/res/xml/file_paths.xml
+++ b/app/src/main/res/xml/file_paths.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <paths>
+    <cache-path name="cache" path="." />
     <cache-path name="images" path="images/" />
 </paths>


### PR DESCRIPTION
## Summary
- include the cache directory in `file_paths.xml` so FileProvider can resolve files written to `cacheDir`

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_685636089910832fb91504ae42b7c711