### PR TITLE
Add Residentes module

### DIFF
--- a/app/src/main/java/com/example/bitacoradigital/model/NodoHoja.kt
+++ b/app/src/main/java/com/example/bitacoradigital/model/NodoHoja.kt
@@ -1,0 +1,6 @@
+package com.example.bitacoradigital.model
+
+data class NodoHoja(
+    val id: Int,
+    val name: String
+)

--- a/app/src/main/java/com/example/bitacoradigital/model/Residente.kt
+++ b/app/src/main/java/com/example/bitacoradigital/model/Residente.kt
@@ -1,0 +1,10 @@
+package com.example.bitacoradigital.model
+
+data class Residente(
+    val id: Int,
+    val name: String,
+    val email: String,
+    val registrationDate: String,
+    val perimeterName: String,
+    val perimeterId: Int
+)

--- a/app/src/main/java/com/example/bitacoradigital/navigation/NavGraph.kt
+++ b/app/src/main/java/com/example/bitacoradigital/navigation/NavGraph.kt
@@ -25,6 +25,7 @@ import com.example.bitacoradigital.ui.screens.qr.CodigosQRScreen
 import com.example.bitacoradigital.ui.screens.qr.GenerarCodigoQRScreen
 import com.example.bitacoradigital.ui.screens.dashboard.DashboardScreen
 import com.example.bitacoradigital.ui.screens.accesos.AccesosScreen
+import com.example.bitacoradigital.ui.screens.residentes.ResidentesScreen
 import com.example.bitacoradigital.viewmodel.HomeViewModel
 import com.example.bitacoradigital.viewmodel.LoginViewModel
 import com.example.bitacoradigital.viewmodel.SessionViewModel
@@ -153,6 +154,14 @@ fun AppNavGraph(
             AccesosScreen(
                 homeViewModel = homeViewModel,
                 permisos = homeViewModel.perimetroSeleccionado.value?.modulos?.get("Accesos") ?: emptyList(),
+                navController = navController
+            )
+        }
+
+        composable("residentes") {
+            ResidentesScreen(
+                homeViewModel = homeViewModel,
+                permisos = homeViewModel.perimetroSeleccionado.value?.modulos?.get("Residentes") ?: emptyList(),
                 navController = navController
             )
         }

--- a/app/src/main/java/com/example/bitacoradigital/ui/screens/HomeScreen.kt
+++ b/app/src/main/java/com/example/bitacoradigital/ui/screens/HomeScreen.kt
@@ -90,6 +90,7 @@ fun HomeScreen(
                                 "Códigos QR" -> navController.navigate("qr")
                                 "Dashboard" -> navController.navigate("dashboard")
                                 "Accesos" -> navController.navigate("accesos")
+                                "Residentes" -> navController.navigate("residentes")
                                 else -> { }
                             }
                         }

--- a/app/src/main/java/com/example/bitacoradigital/ui/screens/residentes/ResidentesScreen.kt
+++ b/app/src/main/java/com/example/bitacoradigital/ui/screens/residentes/ResidentesScreen.kt
@@ -1,0 +1,172 @@
+package com.example.bitacoradigital.ui.screens.residentes
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.icons.filled.ArrowDropDown
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.viewmodel.compose.viewModel
+import androidx.navigation.NavHostController
+import com.example.bitacoradigital.data.SessionPreferences
+import com.example.bitacoradigital.model.NodoHoja
+import com.example.bitacoradigital.viewmodel.HomeViewModel
+import com.example.bitacoradigital.viewmodel.ResidentesViewModel
+import com.example.bitacoradigital.viewmodel.ResidentesViewModelFactory
+import com.example.bitacoradigital.ui.components.HomeConfigNavBar
+
+@Composable
+fun ResidentesScreen(
+    homeViewModel: HomeViewModel,
+    permisos: List<String>,
+    navController: NavHostController
+) {
+    val perimetroSeleccionado by homeViewModel.perimetroSeleccionado.collectAsState()
+    val perimetroId = perimetroSeleccionado?.perimetroId ?: return
+    val empresaId = perimetroSeleccionado?.empresaId ?: return
+    val context = LocalContext.current
+    val prefs = remember { SessionPreferences(context) }
+    val viewModel: ResidentesViewModel = viewModel(
+        factory = ResidentesViewModelFactory(prefs, perimetroId, empresaId)
+    )
+
+    val residentes by viewModel.residentes.collectAsState()
+    val nodosHoja by viewModel.nodosHoja.collectAsState()
+    val cargando by viewModel.cargando.collectAsState()
+    val error by viewModel.error.collectAsState()
+
+    val puedeCrear = "Crear Residente" in permisos
+    val puedeEliminar = "Eliminar Residente" in permisos
+
+    var mostrarDialogo by remember { mutableStateOf(false) }
+    var correo by remember { mutableStateOf("") }
+    var nodoSeleccionado by remember { mutableStateOf<NodoHoja?>(null) }
+
+    LaunchedEffect(Unit) {
+        viewModel.cargarResidentes()
+        if (puedeCrear) viewModel.cargarNodosHoja()
+    }
+
+    val snackbarHostState = remember { SnackbarHostState() }
+    error?.let { msg ->
+        LaunchedEffect(msg) {
+            snackbarHostState.showSnackbar(msg)
+            viewModel.clearError()
+        }
+    }
+
+    Scaffold(
+        bottomBar = {
+            HomeConfigNavBar(
+                current = "",
+                onHomeClick = { navController.navigate("home") },
+                onConfigClick = { navController.navigate("configuracion") }
+            )
+        },
+        snackbarHost = { SnackbarHost(snackbarHostState) },
+        floatingActionButton = {
+            if (puedeCrear) {
+                FloatingActionButton(onClick = { mostrarDialogo = true }) {
+                    Icon(Icons.Default.Add, contentDescription = null)
+                }
+            }
+        }
+    ) { innerPadding ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(innerPadding)
+                .padding(16.dp)
+        ) {
+            Text(
+                text = "Residentes",
+                style = MaterialTheme.typography.headlineSmall,
+                modifier = Modifier.padding(bottom = 8.dp)
+            )
+            if (cargando) {
+                CircularProgressIndicator()
+            } else {
+                LazyColumn(verticalArrangement = Arrangement.spacedBy(8.dp), modifier = Modifier.weight(1f)) {
+                    items(residentes) { res ->
+                        Card(modifier = Modifier.fillMaxWidth()) {
+                            Row(
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .padding(8.dp),
+                                verticalAlignment = Alignment.CenterVertically
+                            ) {
+                                Column(Modifier.weight(1f)) {
+                                    Text(res.name)
+                                    Text(res.email, style = MaterialTheme.typography.bodySmall)
+                                    Text(res.perimeterName, style = MaterialTheme.typography.bodySmall)
+                                }
+                                if (puedeEliminar) {
+                                    IconButton(onClick = { viewModel.eliminarResidente(res.id, res.perimeterId) }) {
+                                        Icon(Icons.Default.Delete, contentDescription = null)
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    if (mostrarDialogo) {
+        AlertDialog(
+            onDismissRequest = { mostrarDialogo = false },
+            confirmButton = {
+                TextButton(onClick = {
+                    val nodoId = nodoSeleccionado?.id
+                    if (!correo.contains("@") || nodoId == null) return@TextButton
+                    viewModel.invitarResidente(correo, nodoId)
+                    correo = ""
+                    nodoSeleccionado = null
+                    mostrarDialogo = false
+                }) { Text("Invitar") }
+            },
+            dismissButton = { TextButton(onClick = { mostrarDialogo = false }) { Text("Cancelar") } },
+            title = { Text("Invitar Residente") },
+            text = {
+                Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                    OutlinedTextField(
+                        value = correo,
+                        onValueChange = { correo = it },
+                        label = { Text("Correo electrónico") },
+                        modifier = Modifier.fillMaxWidth()
+                    )
+                    var expanded by remember { mutableStateOf(false) }
+                    ExposedDropdownMenuBox(expanded = expanded, onExpandedChange = { expanded = it }) {
+                        OutlinedTextField(
+                            readOnly = true,
+                            value = nodoSeleccionado?.name ?: "",
+                            onValueChange = {},
+                            label = { Text("Perímetro") },
+                            trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = expanded) },
+                            modifier = Modifier.menuAnchor().fillMaxWidth()
+                        )
+                        ExposedDropdownMenu(expanded = expanded, onDismissRequest = { expanded = false }) {
+                            nodosHoja.forEach { nodo ->
+                                DropdownMenuItem(
+                                    text = { Text(nodo.name) },
+                                    onClick = {
+                                        nodoSeleccionado = nodo
+                                        expanded = false
+                                    }
+                                )
+                            }
+                        }
+                    }
+                }
+            }
+        )
+    }
+}

--- a/app/src/main/java/com/example/bitacoradigital/viewmodel/ResidentesViewModel.kt
+++ b/app/src/main/java/com/example/bitacoradigital/viewmodel/ResidentesViewModel.kt
@@ -1,0 +1,180 @@
+package com.example.bitacoradigital.viewmodel
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.example.bitacoradigital.data.SessionPreferences
+import com.example.bitacoradigital.model.Residente
+import com.example.bitacoradigital.model.NodoHoja
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.RequestBody.Companion.toRequestBody
+import org.json.JSONArray
+import org.json.JSONObject
+
+class ResidentesViewModel(
+    private val prefs: SessionPreferences,
+    private val perimetroId: Int,
+    private val empresaId: Int
+) : ViewModel() {
+
+    private val _residentes = MutableStateFlow<List<Residente>>(emptyList())
+    val residentes: StateFlow<List<Residente>> = _residentes.asStateFlow()
+
+    private val _nodosHoja = MutableStateFlow<List<NodoHoja>>(emptyList())
+    val nodosHoja: StateFlow<List<NodoHoja>> = _nodosHoja.asStateFlow()
+
+    private val _cargando = MutableStateFlow(false)
+    val cargando: StateFlow<Boolean> = _cargando.asStateFlow()
+
+    private val _error = MutableStateFlow<String?>(null)
+    val error: StateFlow<String?> = _error.asStateFlow()
+
+    fun clearError() { _error.value = null }
+
+    fun cargarResidentes() {
+        viewModelScope.launch {
+            _cargando.value = true
+            _error.value = null
+            try {
+                val token = withContext(Dispatchers.IO) { prefs.sessionToken.first() } ?: return@launch
+                val request = Request.Builder()
+                    .url("https://bit.cs3.mx/api/v1/perimetro/${perimetroId}/residentes")
+                    .get()
+                    .addHeader("x-session-token", token)
+                    .build()
+                val client = OkHttpClient()
+                val response = withContext(Dispatchers.IO) { client.newCall(request).execute() }
+                response.use { resp ->
+                    if (resp.isSuccessful) {
+                        val jsonStr = withContext(Dispatchers.IO) { resp.body?.string() }
+                        val arr = JSONArray(jsonStr ?: "[]")
+                        val list = mutableListOf<Residente>()
+                        for (i in 0 until arr.length()) {
+                            val obj = arr.getJSONObject(i)
+                            list.add(
+                                Residente(
+                                    id = obj.optInt("id"),
+                                    name = obj.optString("name"),
+                                    email = obj.optString("email"),
+                                    registrationDate = obj.optString("registrationDate"),
+                                    perimeterName = obj.optString("perimeterName"),
+                                    perimeterId = obj.optInt("perimeterId")
+                                )
+                            )
+                        }
+                        _residentes.value = list
+                    } else {
+                        _error.value = "Error ${resp.code}"
+                    }
+                }
+            } catch (e: Exception) {
+                _error.value = e.localizedMessage
+            } finally {
+                _cargando.value = false
+            }
+        }
+    }
+
+    fun cargarNodosHoja() {
+        viewModelScope.launch {
+            try {
+                val token = withContext(Dispatchers.IO) { prefs.sessionToken.first() } ?: return@launch
+                val request = Request.Builder()
+                    .url("https://bit.cs3.mx/api/v1/perimetro/${perimetroId}/nodos-hoja")
+                    .get()
+                    .addHeader("x-session-token", token)
+                    .build()
+                val client = OkHttpClient()
+                val response = withContext(Dispatchers.IO) { client.newCall(request).execute() }
+                response.use { resp ->
+                    if (resp.isSuccessful) {
+                        val jsonStr = withContext(Dispatchers.IO) { resp.body?.string() }
+                        val arr = JSONArray(jsonStr ?: "[]")
+                        val list = mutableListOf<NodoHoja>()
+                        for (i in 0 until arr.length()) {
+                            val obj = arr.getJSONObject(i)
+                            list.add(NodoHoja(obj.optInt("id"), obj.optString("name")))
+                        }
+                        _nodosHoja.value = list
+                    } else {
+                        _error.value = "Error ${resp.code}"
+                    }
+                }
+            } catch (e: Exception) {
+                _error.value = e.localizedMessage
+            }
+        }
+    }
+
+    fun eliminarResidente(usuarioId: Int, perimetroHojaId: Int) {
+        viewModelScope.launch {
+            _cargando.value = true
+            _error.value = null
+            try {
+                val token = withContext(Dispatchers.IO) { prefs.sessionToken.first() } ?: return@launch
+                val request = Request.Builder()
+                    .url("https://bit.cs3.mx/api/v1/usuario-perimetro/remove/3/${usuarioId}/${perimetroHojaId}/")
+                    .delete()
+                    .addHeader("x-session-token", token)
+                    .build()
+                val client = OkHttpClient()
+                val response = withContext(Dispatchers.IO) { client.newCall(request).execute() }
+                response.use { resp ->
+                    if (resp.isSuccessful) {
+                        cargarResidentes()
+                    } else {
+                        _error.value = "Error ${resp.code}"
+                    }
+                }
+            } catch (e: Exception) {
+                _error.value = e.localizedMessage
+            } finally {
+                _cargando.value = false
+            }
+        }
+    }
+
+    fun invitarResidente(correo: String, nodoHojaId: Int) {
+        viewModelScope.launch {
+            _cargando.value = true
+            _error.value = null
+            try {
+                val token = withContext(Dispatchers.IO) { prefs.sessionToken.first() } ?: return@launch
+                val json = JSONObject().apply {
+                    put("correo", correo)
+                    put("id_empresa", empresaId)
+                    put("id_perimetro", nodoHojaId)
+                    put("id_rol", 3)
+                }
+                val body = json.toString().toRequestBody("application/json".toMediaType())
+                val request = Request.Builder()
+                    .url("https://bit.cs3.mx/api/v1/enviar-invitacion/")
+                    .post(body)
+                    .addHeader("x-session-token", token)
+                    .addHeader("Content-Type", "application/json")
+                    .build()
+                val client = OkHttpClient()
+                val response = withContext(Dispatchers.IO) { client.newCall(request).execute() }
+                response.use { resp ->
+                    if (resp.isSuccessful) {
+                        cargarResidentes()
+                    } else {
+                        _error.value = "Error ${resp.code}"
+                    }
+                }
+            } catch (e: Exception) {
+                _error.value = e.localizedMessage
+            } finally {
+                _cargando.value = false
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/example/bitacoradigital/viewmodel/ResidentesViewModelFactory.kt
+++ b/app/src/main/java/com/example/bitacoradigital/viewmodel/ResidentesViewModelFactory.kt
@@ -1,0 +1,19 @@
+package com.example.bitacoradigital.viewmodel
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import com.example.bitacoradigital.data.SessionPreferences
+
+class ResidentesViewModelFactory(
+    private val prefs: SessionPreferences,
+    private val perimetroId: Int,
+    private val empresaId: Int
+) : ViewModelProvider.Factory {
+    override fun <T : ViewModel> create(modelClass: Class<T>): T {
+        if (modelClass.isAssignableFrom(ResidentesViewModel::class.java)) {
+            @Suppress("UNCHECKED_CAST")
+            return ResidentesViewModel(prefs, perimetroId, empresaId) as T
+        }
+        throw IllegalArgumentException("Unknown ViewModel class")
+    }
+}


### PR DESCRIPTION
## Summary
- add models for residents and nodo hoja
- implement `ResidentesViewModel` with networking logic
- create `ResidentesScreen` UI
- integrate residents module in `HomeScreen` and navigation graph

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68565596aa64832f9e94565d04262642