### PR TITLE
Improve Residentes screen UI

### DIFF
--- a/app/src/main/java/com/example/bitacoradigital/ui/screens/residentes/ResidentesScreen.kt
+++ b/app/src/main/java/com/example/bitacoradigital/ui/screens/residentes/ResidentesScreen.kt
@@ -3,10 +3,17 @@ package com.example.bitacoradigital.ui.screens.residentes
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.foundation.animateItemPlacement
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.ArrowDropDown
+import androidx.compose.material.icons.filled.Person
+import androidx.compose.material.icons.filled.PersonAdd
+import androidx.compose.material.icons.filled.Refresh
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
@@ -73,8 +80,15 @@ fun ResidentesScreen(
         snackbarHost = { SnackbarHost(snackbarHostState) },
         floatingActionButton = {
             if (puedeCrear) {
-                FloatingActionButton(onClick = { mostrarDialogo = true }) {
-                    Icon(Icons.Default.Add, contentDescription = null)
+                FloatingActionButton(
+                    onClick = { mostrarDialogo = true },
+                    containerColor = MaterialTheme.colorScheme.primary
+                ) {
+                    Icon(
+                        Icons.Default.PersonAdd,
+                        contentDescription = null,
+                        tint = MaterialTheme.colorScheme.onPrimary
+                    )
                 }
             }
         }
@@ -85,31 +99,90 @@ fun ResidentesScreen(
                 .padding(innerPadding)
                 .padding(16.dp)
         ) {
-            Text(
-                text = "Residentes",
-                style = MaterialTheme.typography.headlineSmall,
-                modifier = Modifier.padding(bottom = 8.dp)
-            )
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(bottom = 8.dp),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Text(
+                    text = "Residentes",
+                    style = MaterialTheme.typography.headlineSmall,
+                    modifier = Modifier.weight(1f)
+                )
+                IconButton(onClick = { viewModel.cargarResidentes() }) {
+                    Icon(Icons.Default.Refresh, contentDescription = "Refrescar")
+                }
+            }
             if (cargando) {
                 CircularProgressIndicator()
             } else {
-                LazyColumn(verticalArrangement = Arrangement.spacedBy(8.dp), modifier = Modifier.weight(1f)) {
-                    items(residentes) { res ->
-                        Card(modifier = Modifier.fillMaxWidth()) {
-                            Row(
-                                modifier = Modifier
-                                    .fillMaxWidth()
-                                    .padding(8.dp),
-                                verticalAlignment = Alignment.CenterVertically
+                if (residentes.isEmpty()) {
+                    Column(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(top = 40.dp),
+                        horizontalAlignment = Alignment.CenterHorizontally
+                    ) {
+                        Icon(
+                            Icons.Default.People,
+                            contentDescription = null,
+                            tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                            modifier = Modifier.size(64.dp)
+                        )
+                        Spacer(Modifier.height(8.dp))
+                        Text("No hay residentes registrados")
+                    }
+                } else {
+                    LazyColumn(
+                        verticalArrangement = Arrangement.spacedBy(8.dp),
+                        modifier = Modifier.weight(1f)
+                    ) {
+                        items(residentes, key = { it.id }) { res ->
+                            var visible by remember { mutableStateOf(true) }
+                            AnimatedVisibility(
+                                visible = visible,
+                                enter = fadeIn(),
+                                exit = fadeOut()
                             ) {
-                                Column(Modifier.weight(1f)) {
-                                    Text(res.name)
-                                    Text(res.email, style = MaterialTheme.typography.bodySmall)
-                                    Text(res.perimeterName, style = MaterialTheme.typography.bodySmall)
-                                }
-                                if (puedeEliminar) {
-                                    IconButton(onClick = { viewModel.eliminarResidente(res.id, res.perimeterId) }) {
-                                        Icon(Icons.Default.Delete, contentDescription = null)
+                                ElevatedCard(
+                                    modifier = Modifier
+                                        .fillMaxWidth()
+                                        .animateItemPlacement(),
+                                    shape = RoundedCornerShape(16.dp),
+                                    colors = CardDefaults.elevatedCardColors(
+                                        containerColor = MaterialTheme.colorScheme.surfaceVariant
+                                    ),
+                                    elevation = CardDefaults.elevatedCardElevation(8.dp)
+                                ) {
+                                    Row(
+                                        modifier = Modifier
+                                            .fillMaxWidth()
+                                            .padding(12.dp),
+                                        verticalAlignment = Alignment.CenterVertically
+                                    ) {
+                                        Icon(
+                                            Icons.Default.Person,
+                                            contentDescription = null,
+                                            modifier = Modifier.padding(end = 8.dp)
+                                        )
+                                        Column(Modifier.weight(1f)) {
+                                            Text(res.name, style = MaterialTheme.typography.titleMedium)
+                                            Text(res.email, style = MaterialTheme.typography.bodySmall)
+                                            Text(res.perimeterName, style = MaterialTheme.typography.bodySmall)
+                                        }
+                                        if (puedeEliminar) {
+                                            IconButton(onClick = {
+                                                visible = false
+                                                viewModel.eliminarResidente(res.id, res.perimeterId)
+                                            }) {
+                                                Icon(
+                                                    Icons.Default.Delete,
+                                                    contentDescription = null,
+                                                    tint = MaterialTheme.colorScheme.error
+                                                )
+                                            }
+                                        }
                                     }
                                 }
                             }
@@ -121,28 +194,48 @@ fun ResidentesScreen(
     }
 
     if (mostrarDialogo) {
+        var emailError by remember { mutableStateOf(false) }
+        val formValido = correo.contains("@") && nodoSeleccionado != null && !emailError
         AlertDialog(
             onDismissRequest = { mostrarDialogo = false },
             confirmButton = {
-                TextButton(onClick = {
-                    val nodoId = nodoSeleccionado?.id
-                    if (!correo.contains("@") || nodoId == null) return@TextButton
-                    viewModel.invitarResidente(correo, nodoId)
-                    correo = ""
-                    nodoSeleccionado = null
-                    mostrarDialogo = false
-                }) { Text("Invitar") }
+                Button(
+                    onClick = {
+                        val nodoId = nodoSeleccionado?.id ?: return@Button
+                        viewModel.invitarResidente(correo, nodoId)
+                        correo = ""
+                        nodoSeleccionado = null
+                        emailError = false
+                        mostrarDialogo = false
+                    },
+                    enabled = formValido,
+                    colors = ButtonDefaults.buttonColors(containerColor = MaterialTheme.colorScheme.primary)
+                ) { Text("Invitar") }
             },
-            dismissButton = { TextButton(onClick = { mostrarDialogo = false }) { Text("Cancelar") } },
+            dismissButton = {
+                OutlinedButton(onClick = { mostrarDialogo = false }) { Text("Cancelar") }
+            },
             title = { Text("Invitar Residente") },
+            shape = RoundedCornerShape(16.dp),
             text = {
-                Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
                     OutlinedTextField(
                         value = correo,
-                        onValueChange = { correo = it },
+                        onValueChange = {
+                            correo = it
+                            emailError = it.isNotBlank() && !it.contains("@")
+                        },
                         label = { Text("Correo electrónico") },
+                        isError = emailError,
                         modifier = Modifier.fillMaxWidth()
                     )
+                    if (emailError) {
+                        Text(
+                            "Correo inválido",
+                            color = MaterialTheme.colorScheme.error,
+                            style = MaterialTheme.typography.bodySmall
+                        )
+                    }
                     var expanded by remember { mutableStateOf(false) }
                     ExposedDropdownMenuBox(expanded = expanded, onExpandedChange = { expanded = it }) {
                         OutlinedTextField(


### PR DESCRIPTION
## Summary
- restyle ResidentesScreen
- modernize cards for resident list
- show empty state message
- colorize FAB and add refresh button
- redesign invitation dialog with validation

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68565b777dc0832f8d14ef07f3e63953