### PR TITLE
Remove animateItemPlacement usage

### DIFF
--- a/app/src/main/java/com/example/bitacoradigital/ui/screens/residentes/ResidentesScreen.kt
+++ b/app/src/main/java/com/example/bitacoradigital/ui/screens/residentes/ResidentesScreen.kt
@@ -7,7 +7,6 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
-import androidx.compose.foundation.lazy.animateItemPlacement
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.ArrowDropDown
@@ -148,7 +147,6 @@ fun ResidentesScreen(
                                 ElevatedCard(
                                     modifier = Modifier
                                         .fillMaxWidth()
-                                        .animateItemPlacement(),
                                     shape = RoundedCornerShape(16.dp),
                                     colors = CardDefaults.elevatedCardColors(
                                         containerColor = MaterialTheme.colorScheme.surfaceVariant


### PR DESCRIPTION
## Summary
- remove unnecessary animateItemPlacement import
- drop animateItemPlacement modifier in ResidentesScreen

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856696d1554832f9a3d5b47f88b8445