### PR TITLE
Add authorization step to visit registration

### DIFF
--- a/app/src/main/java/com/example/bitacoradigital/model/Residente.kt
+++ b/app/src/main/java/com/example/bitacoradigital/model/Residente.kt
@@ -3,6 +3,7 @@ package com.example.bitacoradigital.model
 data class Residente(
     val id: Int,
     val name: String,
+    val idPersona: Int,
     val email: String,
     val registrationDate: String,
     val perimeterName: String,

--- a/app/src/main/java/com/example/bitacoradigital/ui/screens/RegistroVisitaWizardScreen.kt
+++ b/app/src/main/java/com/example/bitacoradigital/ui/screens/RegistroVisitaWizardScreen.kt
@@ -17,6 +17,7 @@ import com.example.bitacoradigital.data.SessionPreferences
 import com.example.bitacoradigital.network.ApiService
 
 import com.example.bitacoradigital.ui.screens.registrovisita.PasoFinal
+import com.example.bitacoradigital.ui.screens.registrovisita.PasoAutorizacion
 import com.example.bitacoradigital.ui.screens.registrovisita.PasoFotos
 import com.example.bitacoradigital.ui.screens.registrovisita.PasoTelefono
 import com.example.bitacoradigital.ui.screens.registrovisita.PasoVerificacion
@@ -48,7 +49,7 @@ fun RegistroVisitaWizardScreen(perimetroId: Int, navController: NavHostControlle
         }
     ) { innerPadding ->
     Column(modifier = Modifier.fillMaxSize().padding(innerPadding).padding(16.dp)) {
-        Stepper(pasoActual, totalPasos = 7)
+        Stepper(pasoActual, totalPasos = 8)
         Spacer(Modifier.height(24.dp))
 
         when (pasoActual) {
@@ -58,7 +59,8 @@ fun RegistroVisitaWizardScreen(perimetroId: Int, navController: NavHostControlle
             4 -> PasoDestino(viewModel)
             5 -> PasoFotos(viewModel)
             6 -> PasoConfirmacion(viewModel)
-            7 -> PasoFinal(viewModel)
+            7 -> PasoAutorizacion(viewModel)
+            8 -> PasoFinal(viewModel)
         }
     }
     }

--- a/app/src/main/java/com/example/bitacoradigital/ui/screens/registrovisita/PasoAutorizacion.kt
+++ b/app/src/main/java/com/example/bitacoradigital/ui/screens/registrovisita/PasoAutorizacion.kt
@@ -1,0 +1,88 @@
+package com.example.bitacoradigital.ui.screens.registrovisita
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.*
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowDropDown
+import androidx.compose.material.icons.filled.ArrowDropUp
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.unit.dp
+import com.example.bitacoradigital.viewmodel.RegistroVisitaViewModel
+
+@Composable
+fun PasoAutorizacion(viewModel: RegistroVisitaViewModel) {
+    val destino by viewModel.destinoSeleccionado.collectAsState()
+    val residentes by viewModel.residentesDestino.collectAsState()
+    val invitanteId by viewModel.invitanteId.collectAsState()
+    val cargando by viewModel.cargandoResidentes.collectAsState()
+    val error by viewModel.errorResidentes.collectAsState()
+    val cargandoReg by viewModel.cargandoRegistro.collectAsState()
+    val registroCompleto by viewModel.registroCompleto.collectAsState()
+    val context = LocalContext.current
+
+    LaunchedEffect(destino) {
+        destino?.let { viewModel.cargarResidentesDestino(it.perimetro_id) }
+    }
+
+    LaunchedEffect(registroCompleto) {
+        if (registroCompleto) viewModel.avanzarPaso()
+    }
+
+    var expanded by remember { mutableStateOf(false) }
+    val seleccionado = residentes.find { it.idPersona == invitanteId }
+
+    Box(Modifier.fillMaxSize()) {
+        Column(modifier = Modifier.fillMaxSize().padding(16.dp)) {
+            Text("Paso 7: ¿Quién autorizó?", style = MaterialTheme.typography.titleLarge)
+            Spacer(Modifier.height(16.dp))
+
+            if (cargando) {
+                CircularProgressIndicator()
+            } else if (error != null) {
+                Text(error ?: "", color = MaterialTheme.colorScheme.error)
+            } else {
+                ExposedDropdownMenuBox(expanded = expanded, onExpandedChange = { expanded = it }) {
+                    OutlinedTextField(
+                        value = seleccionado?.name ?: "",
+                        onValueChange = {},
+                        readOnly = true,
+                        label = { Text("Residente") },
+                        trailingIcon = {
+                            if (expanded) Icon(Icons.Default.ArrowDropUp, contentDescription = null)
+                            else Icon(Icons.Default.ArrowDropDown, contentDescription = null)
+                        },
+                        modifier = Modifier.menuAnchor().fillMaxWidth()
+                    )
+                    ExposedDropdownMenu(expanded = expanded, onDismissRequest = { expanded = false }) {
+                        residentes.forEach { res ->
+                            DropdownMenuItem(text = { Text(res.name) }, onClick = {
+                                viewModel.invitanteId.value = res.idPersona
+                                expanded = false
+                            })
+                        }
+                    }
+                }
+            }
+
+            Spacer(Modifier.height(24.dp))
+            Button(
+                onClick = { viewModel.registrarVisita(context) },
+                enabled = invitanteId != null,
+                modifier = Modifier.fillMaxWidth()
+            ) {
+                Text("Finalizar Registro")
+            }
+        }
+
+        if (cargandoReg) {
+            Box(
+                modifier = Modifier.fillMaxSize().background(MaterialTheme.colorScheme.background.copy(alpha = 0.5f)),
+                contentAlignment = Alignment.Center
+            ) { CircularProgressIndicator() }
+        }
+    }
+}

--- a/app/src/main/java/com/example/bitacoradigital/ui/screens/registrovisita/PasoConfirmacion.kt
+++ b/app/src/main/java/com/example/bitacoradigital/ui/screens/registrovisita/PasoConfirmacion.kt
@@ -2,29 +2,18 @@
 package com.example.bitacoradigital.ui.screens.registrovisita
 
 import android.net.Uri
-import androidx.compose.foundation.Image
-import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.CheckCircle
+import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.foundation.layout.*
-import androidx.compose.foundation.lazy.LazyRow
-import androidx.compose.foundation.lazy.items
-import androidx.compose.foundation.Image
-import androidx.compose.material.icons.filled.Delete
-import androidx.compose.material3.*
-import androidx.compose.runtime.*
-import androidx.compose.ui.unit.dp
-import coil.compose.AsyncImage
-import androidx.compose.ui.platform.LocalContext
-
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import coil.compose.AsyncImage
 import com.example.bitacoradigital.viewmodel.RegistroVisitaViewModel
@@ -39,14 +28,7 @@ fun PasoConfirmacion(viewModel: RegistroVisitaViewModel) {
     val destino by viewModel.destinoSeleccionado.collectAsState()
     val fotos by viewModel.fotosAdicionales.collectAsState()
 
-    val cargando by viewModel.cargandoRegistro.collectAsState()
-    val registroCompleto by viewModel.registroCompleto.collectAsState()
 
-    LaunchedEffect(registroCompleto) {
-        if (registroCompleto) {
-            viewModel.avanzarPaso()
-        }
-    }
 
     Box(Modifier.fillMaxSize()) {
         Column(modifier = Modifier
@@ -101,24 +83,12 @@ fun PasoConfirmacion(viewModel: RegistroVisitaViewModel) {
 
         Spacer(Modifier.height(24.dp))
 
-        val context = LocalContext.current
         Button(
-            onClick = {
-                viewModel.registrarVisita(context)
-            },
+            onClick = { viewModel.avanzarPaso() },
             modifier = Modifier.fillMaxWidth()
         ) {
-            Text("Finalizar Registro")
+            Text("Siguiente")
         }
-        }
-
-        if (cargando) {
-            Box(
-                modifier = Modifier
-                    .fillMaxSize()
-                    .background(MaterialTheme.colorScheme.background.copy(alpha = 0.5f)),
-                contentAlignment = Alignment.Center
-            ) { CircularProgressIndicator() }
         }
     }
 }

--- a/app/src/main/java/com/example/bitacoradigital/viewmodel/ResidentesViewModel.kt
+++ b/app/src/main/java/com/example/bitacoradigital/viewmodel/ResidentesViewModel.kt
@@ -63,6 +63,7 @@ class ResidentesViewModel(
                                 Residente(
                                     id = obj.optInt("id"),
                                     name = obj.optString("name"),
+                                    idPersona = obj.optInt("id_persona"),
                                     email = obj.optString("email"),
                                     registrationDate = obj.optString("registrationDate"),
                                     perimeterName = obj.optString("perimeterName"),


### PR DESCRIPTION
## Summary
- extend `Residente` model with `idPersona`
- fetch perimeter residents in `RegistroVisitaViewModel`
- add `PasoAutorizacion` screen and update wizard
- adjust confirmation step to lead into new authorization step

## Testing
- `./gradlew tasks --quiet`
- `./gradlew test --quiet` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68566c52c07c832f818f2d890d4a6d4c