### PR TITLE
Fix missing cleanup of document photo

### DIFF
--- a/app/src/main/java/com/example/bitacoradigital/viewmodel/RegistroVisitaViewModel.kt
+++ b/app/src/main/java/com/example/bitacoradigital/viewmodel/RegistroVisitaViewModel.kt
@@ -111,6 +111,7 @@ class RegistroVisitaViewModel(
         numeroVerificado.value = false
         tipoDocumento.value = null
         fotoDocumentoUri.value = null
+        documentoUri.value = null
         nombre.value = ""
         apellidoPaterno.value = ""
         apellidoMaterno.value = ""


### PR DESCRIPTION
## Summary
- clear `documentoUri` when restarting the visit flow

## Testing
- `./gradlew test --no-daemon` *(fails: Could not determine the dependencies of task ':app:testDebugUnitTest')*

------
https://chatgpt.com/codex/tasks/task_e_6856715d2024832f9035a9161aabf3d3