### PR TITLE
Add QR management screen and viewmodel

### DIFF
--- a/app/src/main/java/com/example/bitacoradigital/model/CodigoQR.kt
+++ b/app/src/main/java/com/example/bitacoradigital/model/CodigoQR.kt
@@ -1,0 +1,13 @@
+package com.example.bitacoradigital.model
+
+/** Modelo para una invitación de QR */
+data class CodigoQR(
+    val id_invitacion: Int,
+    val id_telefono: Int,
+    val telefono: String,
+    val lada: String?,
+    val id_cad_invitacion: Int,
+    val id_cad_qr: Int,
+    val timestamp_inicio: Long,
+    val timestamp_final: Long
+)

--- a/app/src/main/java/com/example/bitacoradigital/ui/screens/qr/CodigosQRScreen.kt
+++ b/app/src/main/java/com/example/bitacoradigital/ui/screens/qr/CodigosQRScreen.kt
@@ -1,30 +1,54 @@
 package com.example.bitacoradigital.ui.screens.qr
 
-import androidx.compose.foundation.clickable
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.QrCode
-import androidx.compose.material3.Card
-import androidx.compose.material3.CardDefaults
-import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Scaffold
-import androidx.compose.material3.Text
-import androidx.compose.runtime.Composable
+import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.icons.filled.Edit
+import androidx.compose.material.icons.filled.Refresh
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
+import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavHostController
+import com.example.bitacoradigital.data.SessionPreferences
+import com.example.bitacoradigital.model.CodigoQR
 import com.example.bitacoradigital.ui.components.HomeConfigNavBar
+import com.example.bitacoradigital.util.toReadableDate
+import com.example.bitacoradigital.viewmodel.CodigosQRViewModel
+import com.example.bitacoradigital.viewmodel.CodigosQRViewModelFactory
 
 @Composable
 fun CodigosQRScreen(permisos: List<String>, navController: NavHostController) {
+    val context = LocalContext.current
+    val prefs = remember { SessionPreferences(context) }
+    val viewModel: CodigosQRViewModel = viewModel(factory = CodigosQRViewModelFactory(prefs))
+
+    val codigos by viewModel.codigos.collectAsState()
+    val cargando by viewModel.cargando.collectAsState()
+    val error by viewModel.error.collectAsState()
+
+    val puedeVer = "Ver Códigos QR" in permisos
+    val puedeEliminar = "Eliminar Código QR" in permisos
+    val puedeModificar = "Modificar Código QR" in permisos
+
+    LaunchedEffect(Unit) { if (puedeVer) viewModel.cargarCodigos() }
+
+    var modificar by remember { mutableStateOf<CodigoQR?>(null) }
+    var diasExtra by remember { mutableStateOf("") }
+
+    val snackbarHostState = remember { SnackbarHostState() }
+    error?.let { msg ->
+        LaunchedEffect(msg) {
+            snackbarHostState.showSnackbar(msg)
+            viewModel.cargarCodigos()
+        }
+    }
+
     Scaffold(
         bottomBar = {
             HomeConfigNavBar(
@@ -32,22 +56,100 @@ fun CodigosQRScreen(permisos: List<String>, navController: NavHostController) {
                 onHomeClick = { navController.navigate("home") },
                 onConfigClick = { navController.navigate("configuracion") }
             )
-        }
+        },
+        snackbarHost = { SnackbarHost(snackbarHostState) }
     ) { innerPadding ->
-    Column(
-        modifier = Modifier
-            .fillMaxSize()
-            .padding(innerPadding)
-            .padding(16.dp),
-        verticalArrangement = Arrangement.spacedBy(16.dp)
-    ) {
-        Text(
-            text = "Códigos QR",
-            style = MaterialTheme.typography.headlineSmall,
-            modifier = Modifier.padding(bottom = 8.dp)
-        )
-
-        // Este módulo ya no contiene submódulos activos
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(innerPadding)
+                .padding(16.dp)
+        ) {
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(bottom = 8.dp),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Text(
+                    text = "Códigos QR",
+                    style = MaterialTheme.typography.headlineSmall,
+                    modifier = Modifier.weight(1f)
+                )
+                IconButton(onClick = { viewModel.cargarCodigos() }) {
+                    Icon(Icons.Default.Refresh, contentDescription = null)
+                }
+            }
+            if (!puedeVer) {
+                Text("Sin permisos para ver códigos")
+            } else if (cargando) {
+                CircularProgressIndicator()
+            } else {
+                if (codigos.isEmpty()) {
+                    Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                        Text("Sin códigos activos")
+                    }
+                } else {
+                    LazyColumn(
+                        modifier = Modifier.weight(1f),
+                        verticalArrangement = Arrangement.spacedBy(8.dp)
+                    ) {
+                        items(codigos, key = { it.id_invitacion }) { qr ->
+                            Card(modifier = Modifier.fillMaxWidth()) {
+                                Row(
+                                    Modifier
+                                        .fillMaxWidth()
+                                        .padding(8.dp),
+                                    verticalAlignment = Alignment.CenterVertically
+                                ) {
+                                    Column(Modifier.weight(1f)) {
+                                        Text(qr.telefono)
+                                        Text("Inicio: ${qr.timestamp_inicio.toReadableDate()}", style = MaterialTheme.typography.bodySmall)
+                                        Text("Fin: ${qr.timestamp_final.toReadableDate()}", style = MaterialTheme.typography.bodySmall)
+                                    }
+                                    if (puedeModificar) {
+                                        IconButton(onClick = { modificar = qr; diasExtra = "" }) {
+                                            Icon(Icons.Default.Edit, contentDescription = null)
+                                        }
+                                    }
+                                    if (puedeEliminar) {
+                                        IconButton(onClick = { viewModel.borrarCodigo(qr.id_invitacion) }) {
+                                            Icon(Icons.Default.Delete, contentDescription = null)
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
     }
+
+    modificar?.let { qr ->
+        AlertDialog(
+            onDismissRequest = { modificar = null },
+            confirmButton = {
+                TextButton(onClick = {
+                    diasExtra.toIntOrNull()?.let { viewModel.modificarCaducidad(qr.id_invitacion, it) }
+                    modificar = null
+                }, enabled = diasExtra.toIntOrNull() != null) {
+                    Text("Guardar")
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = { modificar = null }) { Text("Cancelar") }
+            },
+            title = { Text("Modificar caducidad") },
+            text = {
+                OutlinedTextField(
+                    value = diasExtra,
+                    onValueChange = { diasExtra = it },
+                    label = { Text("Días de duración") },
+                    modifier = Modifier.fillMaxWidth(),
+                    keyboardOptions = androidx.compose.foundation.text.KeyboardOptions(keyboardType = androidx.compose.ui.text.input.KeyboardType.Number)
+                )
+            }
+        )
     }
 }

--- a/app/src/main/java/com/example/bitacoradigital/util/Constants.kt
+++ b/app/src/main/java/com/example/bitacoradigital/util/Constants.kt
@@ -3,3 +3,12 @@ package com.example.bitacoradigital.util
 object Constants {
     const val FILE_PROVIDER_AUTHORITY: String = "com.example.bitacoradigital.fileprovider"
 }
+
+import java.text.SimpleDateFormat
+import java.util.*
+
+fun Long.toReadableDate(): String {
+    val date = Date(this)
+    val format = SimpleDateFormat("yyyy-MM-dd HH:mm", Locale.getDefault())
+    return format.format(date)
+}

--- a/app/src/main/java/com/example/bitacoradigital/viewmodel/CodigosQRViewModel.kt
+++ b/app/src/main/java/com/example/bitacoradigital/viewmodel/CodigosQRViewModel.kt
@@ -1,0 +1,153 @@
+package com.example.bitacoradigital.viewmodel
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.viewModelScope
+import com.example.bitacoradigital.data.SessionPreferences
+import com.example.bitacoradigital.model.CodigoQR
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.firstOrNull
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.RequestBody.Companion.toRequestBody
+import org.json.JSONArray
+import org.json.JSONObject
+
+class CodigosQRViewModel(private val prefs: SessionPreferences) : ViewModel() {
+
+    private val _codigos = MutableStateFlow<List<CodigoQR>>(emptyList())
+    val codigos: StateFlow<List<CodigoQR>> = _codigos.asStateFlow()
+
+    private val _cargando = MutableStateFlow(false)
+    val cargando: StateFlow<Boolean> = _cargando.asStateFlow()
+
+    private val _error = MutableStateFlow<String?>(null)
+    val error: StateFlow<String?> = _error.asStateFlow()
+
+    fun cargarCodigos() {
+        viewModelScope.launch {
+            _cargando.value = true
+            _error.value = null
+            try {
+                val id = withContext(Dispatchers.IO) { prefs.personaId.firstOrNull() } ?: return@launch
+                val request = Request.Builder()
+                    .url("http://qr.cs3.mx/bite/consultar-qr/$id")
+                    .get()
+                    .addHeader("Authorization", "Bearer mfmssmcl")
+                    .build()
+                val client = OkHttpClient()
+                val response = withContext(Dispatchers.IO) { client.newCall(request).execute() }
+                response.use { resp ->
+                    if (resp.isSuccessful) {
+                        val jsonStr = withContext(Dispatchers.IO) { resp.body?.string() }
+                        val list = mutableListOf<CodigoQR>()
+                        if (!jsonStr.isNullOrBlank()) {
+                            val arr = JSONObject(jsonStr).optJSONArray("invitaciones") ?: JSONArray()
+                            for (i in 0 until arr.length()) {
+                                val obj = arr.getJSONObject(i)
+                                list.add(
+                                    CodigoQR(
+                                        id_invitacion = obj.optInt("id_invitacion"),
+                                        id_telefono = obj.optInt("id_telefono"),
+                                        telefono = obj.optString("telefono"),
+                                        lada = if (obj.isNull("lada")) null else obj.optString("lada"),
+                                        id_cad_invitacion = obj.optInt("id_cad_invitacion"),
+                                        id_cad_qr = obj.optInt("id_cad_qr"),
+                                        timestamp_inicio = obj.optString("timestamp_inicio").toLongOrNull() ?: 0L,
+                                        timestamp_final = obj.optString("timestamp_final").toLongOrNull() ?: 0L
+                                    )
+                                )
+                            }
+                        }
+                        _codigos.value = list
+                    } else {
+                        _error.value = "Error ${resp.code}"
+                    }
+                }
+            } catch (e: Exception) {
+                _error.value = e.localizedMessage
+            } finally {
+                _cargando.value = false
+            }
+        }
+    }
+
+    fun borrarCodigo(id: Int) {
+        viewModelScope.launch {
+            _cargando.value = true
+            _error.value = null
+            try {
+                val json = JSONObject().apply { put("id_invitacion", id) }
+                val body = json.toString().toRequestBody("application/json".toMediaType())
+                val request = Request.Builder()
+                    .url("http://qr.cs3.mx/bite/borrar-qr/")
+                    .post(body)
+                    .addHeader("Authorization", "Bearer mfmssmcl")
+                    .addHeader("Content-Type", "application/json")
+                    .build()
+                val client = OkHttpClient()
+                val response = withContext(Dispatchers.IO) { client.newCall(request).execute() }
+                response.use { resp ->
+                    if (resp.isSuccessful) {
+                        cargarCodigos()
+                    } else {
+                        _error.value = "Error ${resp.code}"
+                    }
+                }
+            } catch (e: Exception) {
+                _error.value = e.localizedMessage
+            } finally {
+                _cargando.value = false
+            }
+        }
+    }
+
+    fun modificarCaducidad(id: Int, dias: Int) {
+        viewModelScope.launch {
+            _cargando.value = true
+            _error.value = null
+            try {
+                val json = JSONObject().apply {
+                    put("id_invitacion", id)
+                    put("dias_extra", dias)
+                }
+                val body = json.toString().toRequestBody("application/json".toMediaType())
+                val request = Request.Builder()
+                    .url("http://qr.cs3.mx/bite/modificar-cad/")
+                    .post(body)
+                    .addHeader("Authorization", "Bearer mfmssmcl")
+                    .addHeader("Content-Type", "application/json")
+                    .build()
+                val client = OkHttpClient()
+                val response = withContext(Dispatchers.IO) { client.newCall(request).execute() }
+                response.use { resp ->
+                    if (resp.isSuccessful) {
+                        cargarCodigos()
+                    } else {
+                        _error.value = "Error ${resp.code}"
+                    }
+                }
+            } catch (e: Exception) {
+                _error.value = e.localizedMessage
+            } finally {
+                _cargando.value = false
+            }
+        }
+    }
+}
+
+class CodigosQRViewModelFactory(private val prefs: SessionPreferences) : ViewModelProvider.Factory {
+    override fun <T : ViewModel> create(modelClass: Class<T>): T {
+        if (modelClass.isAssignableFrom(CodigosQRViewModel::class.java)) {
+            @Suppress("UNCHECKED_CAST")
+            return CodigosQRViewModel(prefs) as T
+        }
+        throw IllegalArgumentException("Unknown ViewModel class")
+    }
+}


### PR DESCRIPTION
## Summary
- add `CodigoQR` model
- support timestamp conversion via `toReadableDate`
- implement `CodigosQRViewModel` to fetch, delete and update QR codes
- build a new UI for `CodigosQRScreen`

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68567c463894832f85d638268d934431