### PR TITLE
Update QR list with new API and tracking view

### DIFF
--- a/app/src/main/java/com/example/bitacoradigital/model/CodigoQR.kt
+++ b/app/src/main/java/com/example/bitacoradigital/model/CodigoQR.kt
@@ -1,13 +1,12 @@
 package com.example.bitacoradigital.model
 
-/** Modelo para una invitación de QR */
+/** Modelo para una invitación de QR con detalles */
 data class CodigoQR(
     val id_invitacion: Int,
-    val id_telefono: Int,
-    val telefono: String,
-    val lada: String?,
-    val id_cad_invitacion: Int,
-    val id_cad_qr: Int,
-    val timestamp_inicio: Long,
-    val timestamp_final: Long
+    val nombre_invitado: String,
+    val nombre_invitante: String,
+    val destino: String,
+    val caducidad_dias: Double,
+    val estado: String,
+    val periodo_activo: String
 )

--- a/app/src/main/java/com/example/bitacoradigital/model/SeguimientoQR.kt
+++ b/app/src/main/java/com/example/bitacoradigital/model/SeguimientoQR.kt
@@ -1,0 +1,24 @@
+package com.example.bitacoradigital.model
+
+/** Informacion del seguimiento actual de una invitacion */
+data class SeguimientoInfo(
+    val fase: String,
+    val checkpointActualId: Int?,
+    val checkpointActualNombre: String?,
+    val checkpointActualPerimetro: String?,
+    val siguientePerimetro: String?,
+    val siguiente: List<CheckpointSimple>
+)
+
+/** Modelo simple de checkpoint */
+data class CheckpointSimple(
+    val checkpoint_id: Int,
+    val nombre: String
+)
+
+/** Registro historico de un checkpoint visitado por el QR */
+data class HistorialQR(
+    val fecha: String,
+    val checkpoint: String,
+    val perimetro: String
+)

--- a/app/src/main/java/com/example/bitacoradigital/navigation/NavGraph.kt
+++ b/app/src/main/java/com/example/bitacoradigital/navigation/NavGraph.kt
@@ -23,6 +23,7 @@ import com.example.bitacoradigital.ui.screens.RegistroQRScreen
 import com.example.bitacoradigital.ui.screens.perimetro.PerimetrosScreen
 import com.example.bitacoradigital.ui.screens.qr.CodigosQRScreen
 import com.example.bitacoradigital.ui.screens.qr.GenerarCodigoQRScreen
+import com.example.bitacoradigital.ui.screens.qr.SeguimientoQRScreen
 import com.example.bitacoradigital.ui.screens.dashboard.DashboardScreen
 import com.example.bitacoradigital.ui.screens.accesos.AccesosScreen
 import com.example.bitacoradigital.ui.screens.residentes.ResidentesScreen
@@ -132,7 +133,18 @@ fun AppNavGraph(
         }
 
         composable("qr") {
+            val perimetroId = homeViewModel.perimetroSeleccionado.value?.perimetroId ?: return@composable
             CodigosQRScreen(
+                perimetroId = perimetroId,
+                permisos = homeViewModel.perimetroSeleccionado.value?.modulos?.get("Códigos QR") ?: emptyList(),
+                navController = navController
+            )
+        }
+
+        composable("qr/seguimiento/{id}") { backStackEntry ->
+            val id = backStackEntry.arguments?.getString("id")?.toIntOrNull() ?: return@composable
+            SeguimientoQRScreen(
+                idInvitacion = id,
                 permisos = homeViewModel.perimetroSeleccionado.value?.modulos?.get("Códigos QR") ?: emptyList(),
                 navController = navController
             )

--- a/app/src/main/java/com/example/bitacoradigital/ui/screens/qr/SeguimientoQRScreen.kt
+++ b/app/src/main/java/com/example/bitacoradigital/ui/screens/qr/SeguimientoQRScreen.kt
@@ -1,0 +1,142 @@
+package com.example.bitacoradigital.ui.screens.qr
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.icons.filled.Edit
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.viewmodel.compose.viewModel
+import androidx.navigation.NavHostController
+import com.example.bitacoradigital.data.SessionPreferences
+import com.example.bitacoradigital.model.HistorialQR
+import com.example.bitacoradigital.viewmodel.SeguimientoQRViewModel
+import com.example.bitacoradigital.viewmodel.SeguimientoQRViewModelFactory
+import com.example.bitacoradigital.ui.components.HomeConfigNavBar
+
+@Composable
+fun SeguimientoQRScreen(
+    idInvitacion: Int,
+    permisos: List<String>,
+    navController: NavHostController
+) {
+    val context = LocalContext.current
+    val prefs = remember { SessionPreferences(context) }
+    val viewModel: SeguimientoQRViewModel = viewModel(factory = SeguimientoQRViewModelFactory(prefs, idInvitacion))
+
+    val info by viewModel.info.collectAsState()
+    val historial by viewModel.historial.collectAsState()
+    val cargando by viewModel.cargando.collectAsState()
+    val error by viewModel.error.collectAsState()
+
+    val puedeEliminar = "Eliminar Código QR" in permisos
+    val puedeModificar = "Modificar Código QR" in permisos
+
+    var modificar by remember { mutableStateOf(false) }
+    var diasExtra by remember { mutableStateOf("") }
+
+    var confirmarBorrar by remember { mutableStateOf(false) }
+
+    LaunchedEffect(Unit) { viewModel.cargarTodo() }
+
+    Scaffold(
+        bottomBar = {
+            HomeConfigNavBar(
+                current = "",
+                onHomeClick = { navController.navigate("home") },
+                onConfigClick = { navController.navigate("configuracion") }
+            )
+        }
+    ) { innerPadding ->
+        Column(
+            Modifier
+                .fillMaxSize()
+                .padding(innerPadding)
+                .padding(16.dp)
+        ) {
+            if (cargando) {
+                CircularProgressIndicator(Modifier.align(Alignment.CenterHorizontally))
+            } else if (error != null) {
+                Text(error!!)
+            } else {
+                info?.let { data ->
+                    Text("Fase: ${'$'}{data.fase}")
+                    data.checkpointActualNombre?.let { Text("Actual: ${'$'}it") }
+                    data.siguientePerimetro?.let { Text("Próximo perímetro: ${'$'}it") }
+                    if (data.siguiente.isNotEmpty()) {
+                        Text("Siguientes:")
+                        data.siguiente.forEach { cp ->
+                            Text("- ${'$'}{cp.nombre}")
+                        }
+                    }
+                    Spacer(Modifier.height(8.dp))
+                }
+                Text("Historial:")
+                LazyColumn(
+                    modifier = Modifier.weight(1f),
+                    verticalArrangement = Arrangement.spacedBy(4.dp)
+                ) {
+                    items(historial, key = { it.fecha + it.checkpoint }) { h ->
+                        Text("${'$'}{h.fecha} - ${'$'}{h.checkpoint} (${ '$'}{h.perimetro })")
+                    }
+                }
+                Row(
+                    Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.End
+                ) {
+                    if (puedeModificar) {
+                        IconButton(onClick = { modificar = true }) { Icon(Icons.Default.Edit, contentDescription = null) }
+                    }
+                    if (puedeEliminar) {
+                        IconButton(onClick = { confirmarBorrar = true }) { Icon(Icons.Default.Delete, contentDescription = null) }
+                    }
+                }
+            }
+        }
+    }
+
+    if (modificar) {
+        AlertDialog(
+            onDismissRequest = { modificar = false },
+            confirmButton = {
+                TextButton(onClick = {
+                    diasExtra.toIntOrNull()?.let { viewModel.modificarCaducidad(it) }
+                    modificar = false
+                }, enabled = diasExtra.toIntOrNull() != null) { Text("Guardar") }
+            },
+            dismissButton = { TextButton(onClick = { modificar = false }) { Text("Cancelar") } },
+            title = { Text("Modificar caducidad") },
+            text = {
+                OutlinedTextField(
+                    value = diasExtra,
+                    onValueChange = { diasExtra = it },
+                    label = { Text("Días de duración") },
+                    modifier = Modifier.fillMaxWidth(),
+                    keyboardOptions = androidx.compose.foundation.text.KeyboardOptions(keyboardType = androidx.compose.ui.text.input.KeyboardType.Number)
+                )
+            }
+        )
+    }
+
+    if (confirmarBorrar) {
+        AlertDialog(
+            onDismissRequest = { confirmarBorrar = false },
+            confirmButton = {
+                TextButton(onClick = {
+                    viewModel.borrarCodigo()
+                    confirmarBorrar = false
+                    navController.popBackStack()
+                }) { Text("Borrar") }
+            },
+            dismissButton = { TextButton(onClick = { confirmarBorrar = false }) { Text("Cancelar") } },
+            title = { Text("Eliminar QR") },
+            text = { Text("¿Seguro que deseas eliminar este código?") }
+        )
+    }
+}

--- a/app/src/main/java/com/example/bitacoradigital/viewmodel/SeguimientoQRViewModel.kt
+++ b/app/src/main/java/com/example/bitacoradigital/viewmodel/SeguimientoQRViewModel.kt
@@ -1,0 +1,182 @@
+package com.example.bitacoradigital.viewmodel
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.viewModelScope
+import com.example.bitacoradigital.data.SessionPreferences
+import com.example.bitacoradigital.model.CheckpointSimple
+import com.example.bitacoradigital.model.HistorialQR
+import com.example.bitacoradigital.model.SeguimientoInfo
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.firstOrNull
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.RequestBody.Companion.toRequestBody
+import org.json.JSONArray
+import org.json.JSONObject
+
+class SeguimientoQRViewModel(
+    private val prefs: SessionPreferences,
+    private val idInvitacion: Int
+) : ViewModel() {
+
+    private val _info = MutableStateFlow<SeguimientoInfo?>(null)
+    val info: StateFlow<SeguimientoInfo?> = _info.asStateFlow()
+
+    private val _historial = MutableStateFlow<List<HistorialQR>>(emptyList())
+    val historial: StateFlow<List<HistorialQR>> = _historial.asStateFlow()
+
+    private val _cargando = MutableStateFlow(false)
+    val cargando: StateFlow<Boolean> = _cargando.asStateFlow()
+
+    private val _error = MutableStateFlow<String?>(null)
+    val error: StateFlow<String?> = _error.asStateFlow()
+
+    fun cargarTodo() {
+        viewModelScope.launch {
+            _cargando.value = true
+            _error.value = null
+            try {
+                val token = withContext(Dispatchers.IO) { prefs.sessionToken.firstOrNull() } ?: return@launch
+                cargarInfo(token)
+                cargarHistorial(token)
+            } catch (e: Exception) {
+                _error.value = e.localizedMessage
+            } finally {
+                _cargando.value = false
+            }
+        }
+    }
+
+    private suspend fun cargarInfo(token: String) {
+        val request = Request.Builder()
+            .url("https://bitacora.cs3.mx/api/v1/siguiente-checkpoint/?id_invitacion=${idInvitacion}")
+            .get()
+            .addHeader("x-session-token", token)
+            .build()
+        val client = OkHttpClient()
+        val response = withContext(Dispatchers.IO) { client.newCall(request).execute() }
+        response.use { resp ->
+            if (resp.isSuccessful) {
+                val jsonStr = withContext(Dispatchers.IO) { resp.body?.string() }
+                val obj = JSONObject(jsonStr ?: "{}")
+                val siguienteList = mutableListOf<CheckpointSimple>()
+                val arr = obj.optJSONArray("siguiente") ?: JSONArray()
+                for (i in 0 until arr.length()) {
+                    val item = arr.getJSONObject(i)
+                    siguienteList.add(CheckpointSimple(item.optInt("checkpoint_id"), item.optString("nombre")))
+                }
+                _info.value = SeguimientoInfo(
+                    fase = obj.optString("fase"),
+                    checkpointActualId = obj.optJSONObject("checkpoint_actual")?.optInt("id"),
+                    checkpointActualNombre = obj.optJSONObject("checkpoint_actual")?.optString("nombre"),
+                    checkpointActualPerimetro = obj.optString("checkpoint_actual_perimetro"),
+                    siguientePerimetro = if (obj.isNull("siguiente_perimetro")) null else obj.optString("siguiente_perimetro"),
+                    siguiente = siguienteList
+                )
+            } else {
+                _error.value = "Error ${resp.code}"
+            }
+        }
+    }
+
+    private suspend fun cargarHistorial(token: String) {
+        val request = Request.Builder()
+            .url("https://bitacora.cs3.mx/api/v1/checkpoints/seguimiento-qr/?id_invitacion=${idInvitacion}")
+            .get()
+            .addHeader("x-session-token", token)
+            .build()
+        val client = OkHttpClient()
+        val response = withContext(Dispatchers.IO) { client.newCall(request).execute() }
+        response.use { resp ->
+            if (resp.isSuccessful) {
+                val jsonStr = withContext(Dispatchers.IO) { resp.body?.string() }
+                val arr = JSONArray(jsonStr ?: "[]")
+                val list = mutableListOf<HistorialQR>()
+                for (i in 0 until arr.length()) {
+                    val obj = arr.getJSONObject(i)
+                    list.add(
+                        HistorialQR(
+                            fecha = obj.optString("fecha"),
+                            checkpoint = obj.optString("checkpoint"),
+                            perimetro = obj.optString("perimetro")
+                        )
+                    )
+                }
+                _historial.value = list
+            } else {
+                _error.value = "Error ${resp.code}"
+            }
+        }
+    }
+
+    fun modificarCaducidad(dias: Int) {
+        viewModelScope.launch {
+            _cargando.value = true
+            _error.value = null
+            try {
+                val json = JSONObject().apply {
+                    put("id_invitacion", idInvitacion)
+                    put("dias_extra", dias)
+                }
+                val body = json.toString().toRequestBody("application/json".toMediaType())
+                val request = Request.Builder()
+                    .url("http://qr.cs3.mx/bite/modificar-cad/")
+                    .post(body)
+                    .addHeader("Authorization", "Bearer mfmssmcl")
+                    .addHeader("Content-Type", "application/json")
+                    .build()
+                val client = OkHttpClient()
+                val response = withContext(Dispatchers.IO) { client.newCall(request).execute() }
+                response.close()
+            } catch (e: Exception) {
+                _error.value = e.localizedMessage
+            } finally {
+                _cargando.value = false
+            }
+        }
+    }
+
+    fun borrarCodigo() {
+        viewModelScope.launch {
+            _cargando.value = true
+            _error.value = null
+            try {
+                val json = JSONObject().apply { put("id_invitacion", idInvitacion) }
+                val body = json.toString().toRequestBody("application/json".toMediaType())
+                val request = Request.Builder()
+                    .url("http://qr.cs3.mx/bite/borrar-qr/")
+                    .post(body)
+                    .addHeader("Authorization", "Bearer mfmssmcl")
+                    .addHeader("Content-Type", "application/json")
+                    .build()
+                val client = OkHttpClient()
+                val response = withContext(Dispatchers.IO) { client.newCall(request).execute() }
+                response.close()
+            } catch (e: Exception) {
+                _error.value = e.localizedMessage
+            } finally {
+                _cargando.value = false
+            }
+        }
+    }
+}
+
+class SeguimientoQRViewModelFactory(
+    private val prefs: SessionPreferences,
+    private val idInvitacion: Int
+) : ViewModelProvider.Factory {
+    override fun <T : ViewModel> create(modelClass: Class<T>): T {
+        if (modelClass.isAssignableFrom(SeguimientoQRViewModel::class.java)) {
+            @Suppress("UNCHECKED_CAST")
+            return SeguimientoQRViewModel(prefs, idInvitacion) as T
+        }
+        throw IllegalArgumentException("Unknown ViewModel class")
+    }
+}


### PR DESCRIPTION
## Summary
- switch QR codes API to `invitaciones-detalle` with perimetro parameter
- adapt QR model for new fields
- show expandable cards with tracking button and colour-coded status
- add screen and viewmodel to show invitation tracking and history
- wire new screen in navigation

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_685845cdce60832faa1526357f3df2ba