### PR TITLE
Update Seguimiento QR screen with Compose

### DIFF
--- a/app/src/main/java/com/example/bitacoradigital/ui/screens/qr/SeguimientoQRScreen.kt
+++ b/app/src/main/java/com/example/bitacoradigital/ui/screens/qr/SeguimientoQRScreen.kt
@@ -12,8 +12,6 @@ import androidx.compose.material.icons.filled.Edit
 import androidx.compose.material.icons.filled.LocationOn
 import androidx.compose.material.icons.filled.Visibility
 import androidx.compose.material3.*
-import androidx.compose.material3.AssistChip
-import androidx.compose.material3.AssistChipDefaults
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -24,10 +22,10 @@ import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavHostController
 import com.example.bitacoradigital.data.SessionPreferences
-import com.example.bitacoradigital.model.HistorialQR
+import com.example.bitacoradigital.ui.components.HomeConfigNavBar
+import com.example.bitacoradigital.ui.theme.BrandOrange
 import com.example.bitacoradigital.viewmodel.SeguimientoQRViewModel
 import com.example.bitacoradigital.viewmodel.SeguimientoQRViewModelFactory
-import com.example.bitacoradigital.ui.components.HomeConfigNavBar
 
 @Composable
 fun SeguimientoQRScreen(
@@ -37,7 +35,8 @@ fun SeguimientoQRScreen(
 ) {
     val context = LocalContext.current
     val prefs = remember { SessionPreferences(context) }
-    val viewModel: SeguimientoQRViewModel = viewModel(factory = SeguimientoQRViewModelFactory(prefs, idInvitacion))
+    val viewModel: SeguimientoQRViewModel =
+        viewModel(factory = SeguimientoQRViewModelFactory(prefs, idInvitacion))
 
     val info by viewModel.info.collectAsState()
     val historial by viewModel.historial.collectAsState()
@@ -47,10 +46,9 @@ fun SeguimientoQRScreen(
     val puedeEliminar = "Eliminar Código QR" in permisos
     val puedeModificar = "Modificar Código QR" in permisos
 
-    var modificar by remember { mutableStateOf(false) }
-    var diasExtra by remember { mutableStateOf("") }
-
-    var confirmarBorrar by remember { mutableStateOf(false) }
+    var showModificar by remember { mutableStateOf(false) }
+    var diasExtraText by remember { mutableStateOf("") }
+    var showBorrar by remember { mutableStateOf(false) }
 
     val snackbarHostState = remember { SnackbarHostState() }
     error?.let { msg ->
@@ -69,133 +67,229 @@ fun SeguimientoQRScreen(
             )
         }
     ) { innerPadding ->
-        Column(
-            modifier = Modifier
-                .fillMaxSize()
-                .verticalScroll(rememberScrollState())
-                .padding(innerPadding)
-                .padding(horizontal = 16.dp),
-            verticalArrangement = Arrangement.spacedBy(16.dp),
-            horizontalAlignment = Alignment.CenterHorizontally
-        ) {
-            if (cargando) {
-                Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-                    CircularProgressIndicator()
-                }
-            } else {
+        if (cargando) {
+            Box(
+                Modifier
+                    .fillMaxSize()
+                    .padding(innerPadding),
+                contentAlignment = Alignment.Center
+            ) { CircularProgressIndicator() }
+        } else {
+            Column(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .verticalScroll(rememberScrollState())
+                    .padding(innerPadding)
+                    .padding(horizontal = 16.dp),
+                verticalArrangement = Arrangement.spacedBy(16.dp),
+                horizontalAlignment = Alignment.CenterHorizontally
+            ) {
+                Text(
+                    text = "Seguimiento de invitación",
+                    style = MaterialTheme.typography.titleLarge,
+                    modifier = Modifier.fillMaxWidth(),
+                    textAlign = TextAlign.Center
+                )
+
                 info?.let { data ->
-                    Text(
-                        "Seguimiento de invitación",
-                        style = MaterialTheme.typography.titleLarge,
-                        textAlign = TextAlign.Center,
-                        modifier = Modifier.fillMaxWidth()
-                    )
-
-                    val estado = data.mensaje ?: data.fase
-                    val chipColor = if (estado == "La visita ha concluido")
-                        MaterialTheme.colorScheme.surfaceVariant else Color(0xFFD65930)
-
-                    AssistChip(
-                        onClick = {},
-                        label = { Text(estado) },
-                        leadingIcon = { Icon(Icons.Default.Visibility, contentDescription = null) },
-                        colors = AssistChipDefaults.assistChipColors(
-                            containerColor = chipColor,
-                            labelColor = if (estado == "La visita ha concluido")
-                                MaterialTheme.colorScheme.onSurfaceVariant else Color.White
-                        )
-                    )
-
-                    if (data.checkpointActualNombre == null) {
-                        Text(
-                            "Aún no ha iniciado el recorrido",
-                            style = MaterialTheme.typography.bodyMedium,
-                            textAlign = TextAlign.Center,
-                            modifier = Modifier.fillMaxWidth()
-                        )
-                    } else {
-                        Text(
-                            "Actual: ${'$'}{data.checkpointActualNombre}",
-                            style = MaterialTheme.typography.bodyMedium
-                        )
-                    }
-
-                    data.siguientePerimetro?.let {
-                        AssistChip(
-                            onClick = {},
-                            label = { Text(it) },
-                            leadingIcon = { Icon(Icons.Default.LocationOn, contentDescription = null) },
-                            colors = AssistChipDefaults.assistChipColors(
-                                containerColor = Color(0xFFD65930),
-                                labelColor = Color.White
-                            )
-                        )
-                    }
-
-                    if (data.siguiente.isNotEmpty()) {
-                        FlowRow(
-                            modifier = Modifier.fillMaxWidth(),
-                            horizontalArrangement = Arrangement.spacedBy(8.dp),
-                            verticalArrangement = Arrangement.spacedBy(8.dp)
+                    Card(
+                        shape = RoundedCornerShape(12.dp),
+                        colors = CardDefaults.cardColors(),
+                        elevation = CardDefaults.cardElevation(4.dp)
+                    ) {
+                        Column(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(16.dp),
+                            verticalArrangement = Arrangement.spacedBy(8.dp),
+                            horizontalAlignment = Alignment.CenterHorizontally
                         ) {
-                            data.siguiente.forEach { cp ->
+                            Row(
+                                verticalAlignment = Alignment.CenterVertically,
+                                horizontalArrangement = Arrangement.spacedBy(8.dp)
+                            ) {
+                                Text(
+                                    text = "Estado Actual",
+                                    style = MaterialTheme.typography.titleMedium
+                                )
+
+                                val estado = data.mensaje ?: data.fase
+                                val chipBg = when (estado) {
+                                    "Ingresando" -> Color(0xFFD1FAE5)
+                                    "Concluido", "La visita ha concluido" -> MaterialTheme.colorScheme.surfaceVariant
+                                    else -> MaterialTheme.colorScheme.surfaceVariant
+                                }
+                                val chipText = when (estado) {
+                                    "Ingresando" -> Color(0xFF065F46)
+                                    "Concluido", "La visita ha concluido" -> MaterialTheme.colorScheme.onSurfaceVariant
+                                    else -> MaterialTheme.colorScheme.onSurfaceVariant
+                                }
+
                                 AssistChip(
                                     onClick = {},
-                                    label = { Text(cp.nombre) },
-                                    leadingIcon = {
-                                        Icon(Icons.Default.LocationOn, contentDescription = null)
-                                    },
+                                    label = { Text(estado) },
+                                    leadingIcon = { Icon(Icons.Default.Visibility, contentDescription = null) },
                                     colors = AssistChipDefaults.assistChipColors(
-                                        containerColor = MaterialTheme.colorScheme.surfaceVariant
+                                        containerColor = chipBg,
+                                        labelColor = chipText
+                                    )
+                                )
+                            }
+
+                            if (data.checkpointActualNombre == null) {
+                                Text(
+                                    text = "⚠️ Aún no ha iniciado el recorrido",
+                                    style = MaterialTheme.typography.bodyMedium,
+                                    textAlign = TextAlign.Center,
+                                    modifier = Modifier.fillMaxWidth()
+                                )
+                            } else {
+                                Text(
+                                    text = "Actual: ${data.checkpointActualNombre}",
+                                    style = MaterialTheme.typography.bodyMedium,
+                                    textAlign = TextAlign.Center,
+                                    modifier = Modifier.fillMaxWidth()
+                                )
+                            }
+                        }
+                    }
+
+                    data.siguientePerimetro?.let { next ->
+                        Card(
+                            shape = RoundedCornerShape(12.dp),
+                            colors = CardDefaults.cardColors(),
+                            elevation = CardDefaults.cardElevation(4.dp)
+                        ) {
+                            Row(
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .padding(16.dp),
+                                verticalAlignment = Alignment.CenterVertically,
+                                horizontalArrangement = Arrangement.spacedBy(8.dp)
+                            ) {
+                                Text(
+                                    text = "Siguiente destino:",
+                                    style = MaterialTheme.typography.titleMedium
+                                )
+                                AssistChip(
+                                    onClick = {},
+                                    label = { Text(next) },
+                                    leadingIcon = { Icon(Icons.Default.LocationOn, contentDescription = null) },
+                                    colors = AssistChipDefaults.assistChipColors(
+                                        containerColor = BrandOrange,
+                                        labelColor = Color.White
                                     )
                                 )
                             }
                         }
                     }
+
+                    if (data.siguiente.isNotEmpty()) {
+                        Card(
+                            shape = RoundedCornerShape(12.dp),
+                            colors = CardDefaults.cardColors(),
+                            elevation = CardDefaults.cardElevation(4.dp)
+                        ) {
+                            Column(
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .padding(16.dp),
+                                verticalArrangement = Arrangement.spacedBy(8.dp)
+                            ) {
+                                Text(
+                                    text = "Próximos checkpoints:",
+                                    style = MaterialTheme.typography.titleMedium
+                                )
+                                FlowRow(
+                                    modifier = Modifier.fillMaxWidth(),
+                                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                                    verticalArrangement = Arrangement.spacedBy(8.dp)
+                                ) {
+                                    data.siguiente.forEach { cp ->
+                                        AssistChip(
+                                            onClick = {},
+                                            label = { Text(cp.nombre) },
+                                            leadingIcon = { Icon(Icons.Default.LocationOn, contentDescription = null) },
+                                            colors = AssistChipDefaults.assistChipColors(
+                                                containerColor = MaterialTheme.colorScheme.surfaceVariant,
+                                                labelColor = MaterialTheme.colorScheme.onSurfaceVariant
+                                            )
+                                        )
+                                    }
+                                }
+                            }
+                        }
+                    }
                 }
 
-                Divider()
-
-                Text(
-                    "Historial de Seguimiento",
-                    style = MaterialTheme.typography.titleMedium,
-                    modifier = Modifier.fillMaxWidth(),
-                    textAlign = TextAlign.Start
-                )
-
-                if (historial.isEmpty()) {
-                    Text(
-                        "No hay historial de seguimiento disponible",
-                        style = MaterialTheme.typography.bodyMedium,
-                        textAlign = TextAlign.Center,
-                        modifier = Modifier.fillMaxWidth()
-                    )
-                } else {
-                    LazyColumn(
-                        modifier = Modifier.fillMaxHeight(0.5f),
-                        verticalArrangement = Arrangement.spacedBy(8.dp)
+                Card(
+                    shape = RoundedCornerShape(12.dp),
+                    colors = CardDefaults.cardColors(),
+                    elevation = CardDefaults.cardElevation(4.dp)
+                ) {
+                    Column(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(16.dp),
+                        verticalArrangement = Arrangement.spacedBy(8.dp),
+                        horizontalAlignment = Alignment.CenterHorizontally
                     ) {
-                        items(historial, key = { it.fecha + it.checkpoint }) { h ->
-                            Text(
-                                "${'$'}{h.fecha} - ${'$'}{h.checkpoint} (${ '$' }{h.perimetro })",
-                                style = MaterialTheme.typography.bodySmall
+                        Text(
+                            text = "\uD83D\uDD50 Historial de seguimiento",
+                            style = MaterialTheme.typography.titleMedium
+                        )
+                        if (historial.isEmpty()) {
+                            Icon(
+                                Icons.Default.LocationOn,
+                                contentDescription = null,
+                                tint = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.3f),
+                                modifier = Modifier.size(48.dp)
                             )
+                            Text(
+                                text = "No hay historial de seguimiento disponible",
+                                style = MaterialTheme.typography.bodyMedium,
+                                textAlign = TextAlign.Center
+                            )
+                        } else {
+                            LazyColumn(
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .fillMaxHeight(0.5f),
+                                verticalArrangement = Arrangement.spacedBy(8.dp)
+                            ) {
+                                items(historial, key = { it.fecha + it.checkpoint }) { h ->
+                                    Card(
+                                        shape = RoundedCornerShape(12.dp),
+                                        colors = CardDefaults.cardColors(),
+                                        elevation = CardDefaults.cardElevation(4.dp),
+                                        modifier = Modifier.fillMaxWidth()
+                                    ) {
+                                        Column(modifier = Modifier.padding(12.dp)) {
+                                            Text(h.fecha, style = MaterialTheme.typography.bodySmall)
+                                            Text(
+                                                "${h.checkpoint} (${h.perimetro})",
+                                                style = MaterialTheme.typography.bodyMedium
+                                            )
+                                        }
+                                    }
+                                }
+                            }
                         }
                     }
                 }
 
                 Row(
-                    Modifier.fillMaxWidth(),
+                    modifier = Modifier.fillMaxWidth(),
                     horizontalArrangement = Arrangement.Center
                 ) {
                     if (puedeModificar) {
-                        IconButton(onClick = { modificar = true }) {
-                            Icon(Icons.Default.Edit, contentDescription = "Editar QR")
+                        IconButton(onClick = { showModificar = true }) {
+                            Icon(Icons.Default.Edit, contentDescription = "Editar")
                         }
                     }
                     if (puedeEliminar) {
-                        IconButton(onClick = { confirmarBorrar = true }) {
-                            Icon(Icons.Default.Delete, contentDescription = "Eliminar QR")
+                        IconButton(onClick = { showBorrar = true }) {
+                            Icon(Icons.Default.Delete, contentDescription = "Eliminar")
                         }
                     }
                 }
@@ -203,42 +297,48 @@ fun SeguimientoQRScreen(
         }
     }
 
-    if (modificar) {
+    if (showModificar) {
         AlertDialog(
-            onDismissRequest = { modificar = false },
+            onDismissRequest = { showModificar = false },
             confirmButton = {
-                TextButton(onClick = {
-                    diasExtra.toIntOrNull()?.let { viewModel.modificarCaducidad(it) }
-                    modificar = false
-                }, enabled = diasExtra.toIntOrNull() != null) { Text("Guardar") }
+                TextButton(
+                    onClick = {
+                        diasExtraText.toIntOrNull()?.let { viewModel.modificarCaducidad(it) }
+                        showModificar = false
+                    },
+                    enabled = diasExtraText.toIntOrNull() != null
+                ) { Text("Guardar") }
             },
-            dismissButton = { TextButton(onClick = { modificar = false }) { Text("Cancelar") } },
+            dismissButton = { TextButton(onClick = { showModificar = false }) { Text("Cancelar") } },
             title = { Text("Modificar caducidad") },
             text = {
                 OutlinedTextField(
-                    value = diasExtra,
-                    onValueChange = { diasExtra = it },
-                    label = { Text("Días de duración") },
+                    value = diasExtraText,
+                    onValueChange = { diasExtraText = it },
+                    label = { Text("Días extra") },
                     modifier = Modifier.fillMaxWidth(),
-                    keyboardOptions = androidx.compose.foundation.text.KeyboardOptions(keyboardType = androidx.compose.ui.text.input.KeyboardType.Number)
+                    keyboardOptions = androidx.compose.foundation.text.KeyboardOptions(
+                        keyboardType = androidx.compose.ui.text.input.KeyboardType.Number
+                    )
                 )
             }
         )
     }
 
-    if (confirmarBorrar) {
+    if (showBorrar) {
         AlertDialog(
-            onDismissRequest = { confirmarBorrar = false },
+            onDismissRequest = { showBorrar = false },
             confirmButton = {
                 TextButton(onClick = {
                     viewModel.borrarCodigo()
-                    confirmarBorrar = false
+                    showBorrar = false
                     navController.popBackStack()
                 }) { Text("Borrar") }
             },
-            dismissButton = { TextButton(onClick = { confirmarBorrar = false }) { Text("Cancelar") } },
+            dismissButton = { TextButton(onClick = { showBorrar = false }) { Text("Cancelar") } },
             title = { Text("Eliminar QR") },
             text = { Text("¿Seguro que deseas eliminar este código?") }
         )
     }
 }
+


### PR DESCRIPTION
## Summary
- modernize `SeguimientoQRScreen` using Material3 Compose components
- add color and chip styling for current state and upcoming checkpoints
- show history list in cards
- include edit/delete dialogs

## Testing
- `./gradlew assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68585bcaf9ec832fbd2c0b0dbd5ab5e1