### PR TITLE
Update CodigosQR ViewModel API parameters

### DIFF
--- a/app/src/main/java/com/example/bitacoradigital/navigation/NavGraph.kt
+++ b/app/src/main/java/com/example/bitacoradigital/navigation/NavGraph.kt
@@ -133,9 +133,8 @@ fun AppNavGraph(
         }
 
         composable("qr") {
-            val perimetroId = homeViewModel.perimetroSeleccionado.value?.perimetroId ?: return@composable
             CodigosQRScreen(
-                perimetroId = perimetroId,
+                homeViewModel = homeViewModel,
                 permisos = homeViewModel.perimetroSeleccionado.value?.modulos?.get("Códigos QR") ?: emptyList(),
                 navController = navController
             )

--- a/app/src/main/java/com/example/bitacoradigital/ui/screens/qr/CodigosQRScreen.kt
+++ b/app/src/main/java/com/example/bitacoradigital/ui/screens/qr/CodigosQRScreen.kt
@@ -27,16 +27,21 @@ import com.example.bitacoradigital.model.CodigoQR
 import com.example.bitacoradigital.ui.components.HomeConfigNavBar
 import com.example.bitacoradigital.viewmodel.CodigosQRViewModel
 import com.example.bitacoradigital.viewmodel.CodigosQRViewModelFactory
+import com.example.bitacoradigital.viewmodel.HomeViewModel
 
 @Composable
 fun CodigosQRScreen(
-    perimetroId: Int,
+    homeViewModel: HomeViewModel,
     permisos: List<String>,
     navController: NavHostController
 ) {
+    val perimetroSeleccionado by homeViewModel.perimetroSeleccionado.collectAsState()
+    val perimetroId = perimetroSeleccionado?.perimetroId ?: return
+    val empresaId = perimetroSeleccionado?.empresaId ?: return
     val context = LocalContext.current
     val prefs = remember { SessionPreferences(context) }
-    val viewModel: CodigosQRViewModel = viewModel(factory = CodigosQRViewModelFactory(prefs, perimetroId))
+    val viewModel: CodigosQRViewModel =
+        viewModel(factory = CodigosQRViewModelFactory(prefs, perimetroId, empresaId))
 
     val codigos by viewModel.codigos.collectAsState()
     val cargando by viewModel.cargando.collectAsState()

--- a/app/src/main/java/com/example/bitacoradigital/viewmodel/CodigosQRViewModel.kt
+++ b/app/src/main/java/com/example/bitacoradigital/viewmodel/CodigosQRViewModel.kt
@@ -21,7 +21,8 @@ import org.json.JSONObject
 
 class CodigosQRViewModel(
     private val prefs: SessionPreferences,
-    private val perimetroId: Int
+    private val perimetroId: Int,
+    private val empresaId: Int
 ) : ViewModel() {
 
     private val _codigos = MutableStateFlow<List<CodigoQR>>(emptyList())
@@ -40,7 +41,7 @@ class CodigosQRViewModel(
             try {
                 val token = withContext(Dispatchers.IO) { prefs.sessionToken.firstOrNull() } ?: return@launch
                 val request = Request.Builder()
-                    .url("https://bit.cs3.mx/api/v1/invitaciones-detalle/?perimetro_id=$perimetroId")
+                    .url("https://bit.cs3.mx/api/v1/invitaciones-detalle/?perimetro_id=$perimetroId&empresa_id=$empresaId")
                     .get()
                     .addHeader("x-session-token", token)
                     .build()
@@ -146,12 +147,13 @@ class CodigosQRViewModel(
 
 class CodigosQRViewModelFactory(
     private val prefs: SessionPreferences,
-    private val perimetroId: Int
+    private val perimetroId: Int,
+    private val empresaId: Int
 ) : ViewModelProvider.Factory {
     override fun <T : ViewModel> create(modelClass: Class<T>): T {
         if (modelClass.isAssignableFrom(CodigosQRViewModel::class.java)) {
             @Suppress("UNCHECKED_CAST")
-            return CodigosQRViewModel(prefs, perimetroId) as T
+            return CodigosQRViewModel(prefs, perimetroId, empresaId) as T
         }
         throw IllegalArgumentException("Unknown ViewModel class")
     }


### PR DESCRIPTION
## Summary
- include empresaId in `CodigosQRViewModel` and update the endpoint
- expose empresaId through `CodigosQRViewModelFactory`
- load empresaId in `CodigosQRScreen` using `HomeViewModel`
- update navigation to pass `HomeViewModel` to `CodigosQRScreen`

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859a2a5cce4832fb0b834b67c062cc2