### PR TITLE
Fix nested scroll exception in Seguimiento screen

### DIFF
--- a/app/src/main/java/com/example/bitacoradigital/ui/screens/qr/SeguimientoQRScreen.kt
+++ b/app/src/main/java/com/example/bitacoradigital/ui/screens/qr/SeguimientoQRScreen.kt
@@ -79,7 +79,6 @@ fun SeguimientoQRScreen(
             Column(
                 modifier = Modifier
                     .fillMaxSize()
-                    .verticalScroll(rememberScrollState())
                     .padding(innerPadding)
                     .padding(horizontal = 16.dp),
                 verticalArrangement = Arrangement.spacedBy(16.dp),


### PR DESCRIPTION
## Summary
- remove outer verticalScroll from `SeguimientoQRScreen` to avoid measuring `LazyColumn` with infinite constraints

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859a6a16d34832fb1799614881a5c7e