### PR TITLE
Set logo_topbar as app icon

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -13,9 +13,9 @@
         android:allowBackup="true"
         android:dataExtractionRules="@xml/data_extraction_rules"
         android:fullBackupContent="@xml/backup_rules"
-        android:icon="@mipmap/ic_launcher"
+        android:icon="@drawable/logo_topbar"
         android:label="@string/app_name"
-        android:roundIcon="@mipmap/ic_launcher_round"
+        android:roundIcon="@drawable/logo_topbar"
         android:supportsRtl="true"
         android:theme="@style/Theme.BitacoraDigital"
         tools:targetApi="31">


### PR DESCRIPTION
## Summary
- use `logo_topbar.png` for the application icon

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859ae208f6c832fb9c3241af6b6ddec