### PR TITLE
Implement dashboard modules

### DIFF
--- a/app/src/main/java/com/example/bitacoradigital/model/DashboardModels.kt
+++ b/app/src/main/java/com/example/bitacoradigital/model/DashboardModels.kt
@@ -1,0 +1,20 @@
+package com.example.bitacoradigital.model
+
+/** Respuesta de contadores del dashboard */
+data class DashboardCounts(
+    val total_residentes: Int,
+    val visitas_hoy: Int,
+    val total_qrs: Int
+)
+
+/** Estado de invitaciones por QR */
+data class InvitacionEstado(
+    val estado: String,
+    val cantidad: Int
+)
+
+/** Registros de accesos por día */
+data class VisitasDia(
+    val name: String,
+    val visitas: Int
+)

--- a/app/src/main/java/com/example/bitacoradigital/navigation/NavGraph.kt
+++ b/app/src/main/java/com/example/bitacoradigital/navigation/NavGraph.kt
@@ -193,7 +193,10 @@ fun AppNavGraph(
         }
 
         composable("dashboard") {
-            DashboardScreen(navController = navController)
+            DashboardScreen(
+                homeViewModel = homeViewModel,
+                navController = navController
+            )
         }
 
 

--- a/app/src/main/java/com/example/bitacoradigital/ui/screens/dashboard/DashboardScreen.kt
+++ b/app/src/main/java/com/example/bitacoradigital/ui/screens/dashboard/DashboardScreen.kt
@@ -1,21 +1,43 @@
 package com.example.bitacoradigital.ui.screens.dashboard
 
+import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.CalendarToday
+import androidx.compose.material.icons.filled.People
+import androidx.compose.material.icons.filled.QrCode
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.StrokeCap
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
-import com.example.bitacoradigital.ui.components.HomeConfigNavBar
 import androidx.navigation.NavHostController
+import com.example.bitacoradigital.data.SessionPreferences
+import com.example.bitacoradigital.model.InvitacionEstado
+import com.example.bitacoradigital.model.VisitasDia
+import com.example.bitacoradigital.ui.components.HomeConfigNavBar
+import com.example.bitacoradigital.ui.screens.dashboard.DashboardViewModel
+import com.example.bitacoradigital.viewmodel.DashboardViewModelFactory
+import com.example.bitacoradigital.viewmodel.HomeViewModel
 
 @Composable
 fun DashboardScreen(
-    viewModel: DashboardViewModel = viewModel(),
+    homeViewModel: HomeViewModel,
     navController: NavHostController
 ) {
-    val state = viewModel.uiState.collectAsState().value
+    val context = LocalContext.current
+    val prefs = remember { SessionPreferences(context) }
+    val perimetroId = homeViewModel.perimetroSeleccionado.collectAsState().value?.perimetroId ?: return
+    val viewModel: DashboardViewModel = viewModel(factory = DashboardViewModelFactory(prefs, perimetroId))
+
+    val state by viewModel.state.collectAsState()
+
+    LaunchedEffect(Unit) { viewModel.cargarDatos() }
 
     Scaffold(
         bottomBar = {
@@ -26,41 +48,147 @@ fun DashboardScreen(
             )
         }
     ) { innerPadding ->
-    Column(
-        modifier = Modifier
-            .fillMaxSize()
-            .padding(innerPadding)
-            .padding(24.dp),
-        verticalArrangement = Arrangement.spacedBy(16.dp)
-    ) {
-        Text(
-            text = "Bienvenido, ${state.nombreUsuario}",
-            style = MaterialTheme.typography.headlineSmall
-        )
-
-        Text(
-            text = "Resumen de actividad",
-            style = MaterialTheme.typography.titleMedium
-        )
-
-        Card(
-            modifier = Modifier.fillMaxWidth(),
-            colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.primaryContainer)
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(innerPadding)
+                .padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(16.dp)
         ) {
-            Column(modifier = Modifier.padding(16.dp)) {
-                Text("Visitas registradas hoy: ${state.totalVisitas}")
-                Text("Alertas activas: ${state.totalAlertas}")
+            Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(12.dp)) {
+                DashboardCard(
+                    title = "Residentes",
+                    value = state.counts?.total_residentes ?: 0,
+                    icon = Icons.Default.People
+                )
+                DashboardCard(
+                    title = "Visitas hoy",
+                    value = state.counts?.visitas_hoy ?: 0,
+                    icon = Icons.Default.CalendarToday
+                )
+                DashboardCard(
+                    title = "QRs",
+                    value = state.counts?.total_qrs ?: 0,
+                    icon = Icons.Default.QrCode
+                )
             }
-        }
 
-        Card(
-            modifier = Modifier.fillMaxWidth(),
-            colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.secondaryContainer)
-        ) {
-            Column(modifier = Modifier.padding(16.dp)) {
-                Text("Último escaneo: ${state.ultimoEvento}")
+            Card(modifier = Modifier.fillMaxWidth()) {
+                Column(modifier = Modifier.padding(16.dp)) {
+                    Text("Estado de Invitaciones por QR", style = MaterialTheme.typography.titleMedium)
+                    Spacer(Modifier.height(8.dp))
+                    InvitacionesChart(state.invitaciones)
+                }
+            }
+
+            Card(modifier = Modifier.fillMaxWidth()) {
+                Column(modifier = Modifier.padding(16.dp)) {
+                    Text("Registros de Accesos Semanal", style = MaterialTheme.typography.titleMedium)
+                    Spacer(Modifier.height(8.dp))
+                    VisitasBarChart(state.visitasSemana)
+                }
+            }
+
+            Card(modifier = Modifier.fillMaxWidth()) {
+                Column(modifier = Modifier.padding(16.dp)) {
+                    Text("Tendencia Semanal de Accesos", style = MaterialTheme.typography.titleMedium)
+                    Spacer(Modifier.height(8.dp))
+                    LineChart(state.visitasLinea, Color(0xFF1976D2))
+                }
+            }
+
+            Card(modifier = Modifier.fillMaxWidth()) {
+                Column(modifier = Modifier.padding(16.dp)) {
+                    Text("Tendencia Accesos por QR", style = MaterialTheme.typography.titleMedium)
+                    Spacer(Modifier.height(8.dp))
+                    LineChart(state.visitasLineaQr, Color(0xFFE65100))
+                }
             }
         }
     }
+}
+
+@Composable
+private fun DashboardCard(title: String, value: Int, icon: androidx.compose.ui.graphics.vector.ImageVector) {
+    Card(
+        modifier = Modifier.weight(1f),
+        colors = CardDefaults.cardColors()
+    ) {
+        Row(
+            modifier = Modifier.padding(16.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.SpaceBetween
+        ) {
+            Column {
+                Text(title, color = Color.Gray)
+                Text(value.toString(), style = MaterialTheme.typography.titleLarge)
+            }
+            Box(
+                modifier = Modifier.size(40.dp),
+                contentAlignment = Alignment.Center
+            ) {
+                Surface(shape = CircleShape, color = MaterialTheme.colorScheme.primary.copy(alpha = 0.2f)) {
+                    Icon(icon, contentDescription = null, tint = MaterialTheme.colorScheme.primary, modifier = Modifier.padding(8.dp))
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun InvitacionesChart(data: List<InvitacionEstado>) {
+    val activa = data.firstOrNull { it.estado == "Activa" }?.cantidad ?: 0
+    val expirada = data.firstOrNull { it.estado == "Expirada" }?.cantidad ?: 0
+    Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+        Bar(color = Color(0xFF2196F3), value = activa)
+        Bar(color = Color(0xFFF44336), value = expirada)
+    }
+    Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+        Text("Activa: $activa", color = Color(0xFF2196F3))
+        Text("Expirada: $expirada", color = Color(0xFFF44336))
+    }
+}
+
+@Composable
+private fun Bar(color: Color, value: Int) {
+    Canvas(modifier = Modifier
+        .weight(1f)
+        .height(80.dp)) {
+        val barHeight = size.height * (value / 10f)
+        drawRect(color, topLeft = androidx.compose.ui.geometry.Offset(0f, size.height - barHeight), size = androidx.compose.ui.geometry.Size(size.width, barHeight))
+    }
+}
+
+@Composable
+private fun VisitasBarChart(data: List<VisitasDia>) {
+    Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(4.dp)) {
+        data.forEach { dia ->
+            Canvas(modifier = Modifier
+                .weight(1f)
+                .height(80.dp)) {
+                val barHeight = size.height * (dia.visitas / 10f)
+                drawRect(Color(0xFF1976D2), topLeft = androidx.compose.ui.geometry.Offset(0f, size.height - barHeight), size = androidx.compose.ui.geometry.Size(size.width, barHeight))
+            }
+        }
+    }
+}
+
+@Composable
+private fun LineChart(data: List<VisitasDia>, color: Color) {
+    Canvas(modifier = Modifier
+        .fillMaxWidth()
+        .height(120.dp)) {
+        if (data.isEmpty()) return@Canvas
+        val max = data.maxOf { it.visitas }.coerceAtLeast(1)
+        val stepX = size.width / (data.size - 1)
+        val points = data.mapIndexed { index, d ->
+            androidx.compose.ui.geometry.Offset(stepX * index, size.height - (d.visitas / max.toFloat()) * size.height)
+        }
+        for (i in 0 until points.size - 1) {
+            drawLine(color, points[i], points[i + 1], strokeWidth = 4f, cap = StrokeCap.Round)
+        }
+        points.forEach { p ->
+            drawCircle(color, 6f, p)
+        }
     }
 }

--- a/app/src/main/java/com/example/bitacoradigital/ui/screens/dashboard/DashboardViewModel.kt
+++ b/app/src/main/java/com/example/bitacoradigital/ui/screens/dashboard/DashboardViewModel.kt
@@ -1,25 +1,161 @@
 package com.example.bitacoradigital.ui.screens.dashboard
 
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.example.bitacoradigital.data.SessionPreferences
+import com.example.bitacoradigital.model.DashboardCounts
+import com.example.bitacoradigital.model.InvitacionEstado
+import com.example.bitacoradigital.model.VisitasDia
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import org.json.JSONArray
+import org.json.JSONObject
 
-class DashboardViewModel : ViewModel() {
+class DashboardViewModel(
+    private val prefs: SessionPreferences,
+    private val perimetroId: Int
+) : ViewModel() {
 
-    private val _uiState = MutableStateFlow(
-        DashboardUiState(
-            nombreUsuario = "Admin",
-            totalVisitas = 12,
-            totalAlertas = 2,
-            ultimoEvento = "10:45 AM - Entrada Torre A"
-        )
-    )
-    val uiState: StateFlow<DashboardUiState> = _uiState
+    private val _state = MutableStateFlow(DashboardUiState())
+    val state: StateFlow<DashboardUiState> = _state.asStateFlow()
+
+    private val client = OkHttpClient()
+
+    fun cargarDatos() {
+        viewModelScope.launch {
+            _state.value = _state.value.copy(loading = true, error = null)
+            try {
+                val token = withContext(Dispatchers.IO) { prefs.sessionToken.first() } ?: return@launch
+
+                val counts = getCounts(token)
+                val invitaciones = getInvitaciones(token)
+                val semana = getSemana(token)
+                val semanaLinea = getSemanaGlobal(token)
+                val semanaLineaQr = getSemanaGlobalQr(token)
+
+                _state.value = DashboardUiState(
+                    counts = counts,
+                    invitaciones = invitaciones,
+                    visitasSemana = semana,
+                    visitasLinea = semanaLinea,
+                    visitasLineaQr = semanaLineaQr,
+                    loading = false,
+                    error = null
+                )
+            } catch (e: Exception) {
+                _state.value = _state.value.copy(loading = false, error = e.localizedMessage)
+            }
+        }
+    }
+
+    private suspend fun getCounts(token: String): DashboardCounts? {
+        val request = Request.Builder()
+            .url("https://bit.cs3.mx/api/v1/perimetro/${perimetroId}/dashboard-count/")
+            .get()
+            .addHeader("x-session-token", token)
+            .build()
+        val resp = withContext(Dispatchers.IO) { client.newCall(request).execute() }
+        resp.use { r ->
+            if (!r.isSuccessful) return null
+            val obj = JSONObject(r.body?.string() ?: "{}")
+            return DashboardCounts(
+                total_residentes = obj.optInt("total_residentes"),
+                visitas_hoy = obj.optInt("visitas_hoy"),
+                total_qrs = obj.optInt("total_qrs")
+            )
+        }
+    }
+
+    private suspend fun getInvitaciones(token: String): List<InvitacionEstado> {
+        val request = Request.Builder()
+            .url("https://bit.cs3.mx/api/v1/perimetro/${perimetroId}/dashboard-invitaciones-estado/")
+            .get()
+            .addHeader("x-session-token", token)
+            .build()
+        val resp = withContext(Dispatchers.IO) { client.newCall(request).execute() }
+        resp.use { r ->
+            if (!r.isSuccessful) return emptyList()
+            val arr = JSONArray(r.body?.string() ?: "[]")
+            val list = mutableListOf<InvitacionEstado>()
+            for (i in 0 until arr.length()) {
+                val obj = arr.getJSONObject(i)
+                list.add(InvitacionEstado(obj.optString("estado"), obj.optInt("cantidad")))
+            }
+            return list
+        }
+    }
+
+    private suspend fun getSemana(token: String): List<VisitasDia> {
+        val request = Request.Builder()
+            .url("https://bit.cs3.mx/api/v1/perimetro/${perimetroId}/dashboard-visitas-semana/")
+            .get()
+            .addHeader("x-session-token", token)
+            .build()
+        val resp = withContext(Dispatchers.IO) { client.newCall(request).execute() }
+        resp.use { r ->
+            if (!r.isSuccessful) return emptyList()
+            val arr = JSONArray(r.body?.string() ?: "[]")
+            val list = mutableListOf<VisitasDia>()
+            for (i in 0 until arr.length()) {
+                val obj = arr.getJSONObject(i)
+                list.add(VisitasDia(obj.optString("name"), obj.optInt("visitas")))
+            }
+            return list
+        }
+    }
+
+    private suspend fun getSemanaGlobal(token: String): List<VisitasDia> {
+        val request = Request.Builder()
+            .url("https://bit.cs3.mx/api/v1/perimetro/${perimetroId}/dashboard-visitas-semana-global/")
+            .get()
+            .addHeader("x-session-token", token)
+            .build()
+        val resp = withContext(Dispatchers.IO) { client.newCall(request).execute() }
+        resp.use { r ->
+            if (!r.isSuccessful) return emptyList()
+            val arr = JSONArray(r.body?.string() ?: "[]")
+            val list = mutableListOf<VisitasDia>()
+            for (i in 0 until arr.length()) {
+                val obj = arr.getJSONObject(i)
+                list.add(VisitasDia(obj.optString("name"), obj.optInt("visitas")))
+            }
+            return list
+        }
+    }
+
+    private suspend fun getSemanaGlobalQr(token: String): List<VisitasDia> {
+        val request = Request.Builder()
+            .url("https://bit.cs3.mx/api/v1/perimetro/${perimetroId}/dashboard-visitas-semana-global-qr/")
+            .get()
+            .addHeader("x-session-token", token)
+            .build()
+        val resp = withContext(Dispatchers.IO) { client.newCall(request).execute() }
+        resp.use { r ->
+            if (!r.isSuccessful) return emptyList()
+            val arr = JSONArray(r.body?.string() ?: "[]")
+            val list = mutableListOf<VisitasDia>()
+            for (i in 0 until arr.length()) {
+                val obj = arr.getJSONObject(i)
+                list.add(VisitasDia(obj.optString("name"), obj.optInt("visitas")))
+            }
+            return list
+        }
+    }
 }
 
 data class DashboardUiState(
-    val nombreUsuario: String,
-    val totalVisitas: Int,
-    val totalAlertas: Int,
-    val ultimoEvento: String
+    val counts: DashboardCounts? = null,
+    val invitaciones: List<InvitacionEstado> = emptyList(),
+    val visitasSemana: List<VisitasDia> = emptyList(),
+    val visitasLinea: List<VisitasDia> = emptyList(),
+    val visitasLineaQr: List<VisitasDia> = emptyList(),
+    val loading: Boolean = false,
+    val error: String? = null
 )

--- a/app/src/main/java/com/example/bitacoradigital/viewmodel/DashboardViewModelFactory.kt
+++ b/app/src/main/java/com/example/bitacoradigital/viewmodel/DashboardViewModelFactory.kt
@@ -1,0 +1,19 @@
+package com.example.bitacoradigital.viewmodel
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import com.example.bitacoradigital.data.SessionPreferences
+import com.example.bitacoradigital.ui.screens.dashboard.DashboardViewModel
+
+class DashboardViewModelFactory(
+    private val prefs: SessionPreferences,
+    private val perimetroId: Int
+) : ViewModelProvider.Factory {
+    override fun <T : ViewModel> create(modelClass: Class<T>): T {
+        if (modelClass.isAssignableFrom(DashboardViewModel::class.java)) {
+            @Suppress("UNCHECKED_CAST")
+            return DashboardViewModel(prefs, perimetroId) as T
+        }
+        throw IllegalArgumentException("Unknown ViewModel class")
+    }
+}


### PR DESCRIPTION
## Summary
- create dashboard data models
- build DashboardViewModel with API calls for counters and charts
- add factory for new ViewModel
- implement DashboardScreen with cards and basic charts
- hook DashboardScreen to navigation

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859e1131f34832f917376f66c9ee46f