### PR TITLE
Fix weight modifier in dashboard

### DIFF
--- a/app/src/main/java/com/example/bitacoradigital/ui/screens/dashboard/DashboardScreen.kt
+++ b/app/src/main/java/com/example/bitacoradigital/ui/screens/dashboard/DashboardScreen.kt
@@ -263,7 +263,7 @@ private fun InvitacionesChart(data: List<InvitacionEstado>) {
 }
 
 @Composable
-private fun BarWithLabel(label: String, value: Int, color: Color) {
+private fun RowScope.BarWithLabel(label: String, value: Int, color: Color) {
     Column(
         modifier = Modifier.weight(1f),
         horizontalAlignment = Alignment.CenterHorizontally


### PR DESCRIPTION
## Summary
- allow `BarWithLabel` to use `Modifier.weight` by making it a `RowScope` extension

## Testing
- `./gradlew assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859ea099e70832fae338b0e6490854d