### PR TITLE
Implementar mejoras de navegación y QR

### DIFF
--- a/app/src/main/java/com/example/bitacoradigital/ui/screens/RegistroQRScreen.kt
+++ b/app/src/main/java/com/example/bitacoradigital/ui/screens/RegistroQRScreen.kt
@@ -51,6 +51,7 @@ fun RegistroQRScreen(perimetroId: Int, navController: NavHostController) {
     val resultado by viewModel.resultado.collectAsState()
     val crop by viewModel.imagenCrop.collectAsState()
     val mostrandoImagen by viewModel.mostrandoImagen.collectAsState()
+    val siguientePerimetro by viewModel.nombreSiguientePerimetro.collectAsState()
     val cargando by viewModel.cargando.collectAsState()
     val error by viewModel.error.collectAsState()
 
@@ -90,6 +91,13 @@ fun RegistroQRScreen(perimetroId: Int, navController: NavHostController) {
             }
         ) { innerPadding ->
             Box(Modifier.fillMaxSize().padding(innerPadding)) {
+                siguientePerimetro?.let { nombre ->
+                    Text(
+                        "Por favor, brinda instrucciones para ir a $nombre",
+                        color = Color.White,
+                        modifier = Modifier.align(Alignment.TopCenter).padding(16.dp)
+                    )
+                }
                 Image(
                     bitmap = crop!!.asImageBitmap(),
                     contentDescription = null,
@@ -151,8 +159,14 @@ fun RegistroQRScreen(perimetroId: Int, navController: NavHostController) {
                 anim.snapTo(0f)
                 anim.animateTo(1f, tween(500))
                 delay(3000)
-                if (res == "valido") viewModel.mostrandoImagen.value = true
-                else viewModel.reiniciar()
+                if (res == "valido") {
+                    viewModel.mostrandoImagen.value = true
+                } else {
+                    viewModel.reiniciar()
+                    navController.navigate("visitas") {
+                        popUpTo("visitas") { inclusive = true }
+                    }
+                }
             }
             CanvasOverlay(color = if (res == "valido") Color(0x8800FF00) else Color(0x88FF0000), progress = anim.value, text = res)
         }

--- a/app/src/main/java/com/example/bitacoradigital/ui/screens/RegistroVisitaWizardScreen.kt
+++ b/app/src/main/java/com/example/bitacoradigital/ui/screens/RegistroVisitaWizardScreen.kt
@@ -60,7 +60,7 @@ fun RegistroVisitaWizardScreen(perimetroId: Int, navController: NavHostControlle
             5 -> PasoFotos(viewModel)
             6 -> PasoConfirmacion(viewModel)
             7 -> PasoAutorizacion(viewModel)
-            8 -> PasoFinal(viewModel)
+            8 -> PasoFinal(viewModel, navController)
         }
     }
     }

--- a/app/src/main/java/com/example/bitacoradigital/ui/screens/registrovisita/PasoFinal.kt
+++ b/app/src/main/java/com/example/bitacoradigital/ui/screens/registrovisita/PasoFinal.kt
@@ -16,9 +16,10 @@ import androidx.core.content.FileProvider
 import java.io.File
 import com.example.bitacoradigital.util.Constants
 import com.example.bitacoradigital.viewmodel.RegistroVisitaViewModel
+import androidx.navigation.NavHostController
 
 @Composable
-fun PasoFinal(viewModel: RegistroVisitaViewModel) {
+fun PasoFinal(viewModel: RegistroVisitaViewModel, navController: NavHostController) {
     val respuesta by viewModel.respuestaRegistro.collectAsState()
     val qrBitmap by viewModel.qrBitmap.collectAsState()
     val context = LocalContext.current
@@ -65,7 +66,12 @@ fun PasoFinal(viewModel: RegistroVisitaViewModel) {
 
         Spacer(modifier = Modifier.height(32.dp))
 
-        Button(onClick = { viewModel.reiniciar() }, modifier = Modifier.fillMaxWidth()) {
+        Button(onClick = {
+            viewModel.reiniciar()
+            navController.navigate("visitas") {
+                popUpTo("visitas") { inclusive = true }
+            }
+        }, modifier = Modifier.fillMaxWidth()) {
             Text("Registrar otra visita")
         }
     }


### PR DESCRIPTION
## Summary
- indicar próximo perímetro después de leer un QR válido
- reanudar la app a la pantalla de registros tras mostrar errores del QR
- permitir regresar al menú de visitas desde el paso final del registro manual
- agregar navegación automática en el flujo de QR

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a1214a30c832f92365cbdb33ea111