### PR TITLE
Fix experimental API imports

### DIFF
--- a/app/src/main/java/com/example/bitacoradigital/ui/screens/HomeScreen.kt
+++ b/app/src/main/java/com/example/bitacoradigital/ui/screens/HomeScreen.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.foundation.Image
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.*
+import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment

--- a/app/src/main/java/com/example/bitacoradigital/ui/screens/RegistroQRScreen.kt
+++ b/app/src/main/java/com/example/bitacoradigital/ui/screens/RegistroQRScreen.kt
@@ -24,6 +24,7 @@ import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.interaction.collectIsPressedAsState
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment

--- a/app/src/main/java/com/example/bitacoradigital/ui/screens/registrovisita/PasoAutorizacion.kt
+++ b/app/src/main/java/com/example/bitacoradigital/ui/screens/registrovisita/PasoAutorizacion.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.layout.*
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowDropDown
 import androidx.compose.material.icons.filled.ArrowDropUp
+import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment

--- a/app/src/main/java/com/example/bitacoradigital/ui/screens/residentes/ResidentesScreen.kt
+++ b/app/src/main/java/com/example/bitacoradigital/ui/screens/residentes/ResidentesScreen.kt
@@ -16,6 +16,7 @@ import androidx.compose.material.icons.filled.People
 import androidx.compose.material.icons.filled.Person
 import androidx.compose.material.icons.filled.PersonAdd
 import androidx.compose.material.icons.filled.Refresh
+import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment


### PR DESCRIPTION
## Summary
- explicitly import `ExperimentalMaterial3Api` in composables that opt in to Material3

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a33aed7d4832fbff8dab9184d65d1