### PR TITLE
Fix email verification input keyboard

### DIFF
--- a/app/src/main/java/com/example/bitacoradigital/ui/screens/auth/VerificationScreen.kt
+++ b/app/src/main/java/com/example/bitacoradigital/ui/screens/auth/VerificationScreen.kt
@@ -40,7 +40,7 @@ fun VerificationScreen(
             value = code,
             onValueChange = { code = it },
             label = { Text("Código de verificación") },
-            keyboardOptions = KeyboardOptions.Default.copy(keyboardType = KeyboardType.Number),
+            keyboardOptions = KeyboardOptions.Default.copy(keyboardType = KeyboardType.Text),
             singleLine = true,
             modifier = Modifier.fillMaxWidth()
         )


### PR DESCRIPTION
## Summary
- fix numeric keyboard on `VerificationScreen` so alphanumeric codes can be entered

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a3fb470fc832f8f25ce129023d234