### PR TITLE
Enable scrolling for smaller screens

### DIFF
--- a/app/src/main/java/com/example/bitacoradigital/ui/screens/RegistroVisitaWizardScreen.kt
+++ b/app/src/main/java/com/example/bitacoradigital/ui/screens/RegistroVisitaWizardScreen.kt
@@ -4,6 +4,8 @@ package com.example.bitacoradigital.ui.screens
 import androidx.compose.runtime.*
 import androidx.compose.material3.*
 import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import com.example.bitacoradigital.viewmodel.RegistroVisitaViewModel
@@ -38,6 +40,7 @@ fun RegistroVisitaWizardScreen(perimetroId: Int, navController: NavHostControlle
     )
 
     val pasoActual by viewModel.pasoActual.collectAsState()
+    val scrollState = rememberScrollState()
 
     Scaffold(
         bottomBar = {
@@ -48,7 +51,13 @@ fun RegistroVisitaWizardScreen(perimetroId: Int, navController: NavHostControlle
             )
         }
     ) { innerPadding ->
-    Column(modifier = Modifier.fillMaxSize().padding(innerPadding).padding(16.dp)) {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(innerPadding)
+            .padding(16.dp)
+            .verticalScroll(scrollState)
+    ) {
         Stepper(pasoActual, totalPasos = 8)
         Spacer(Modifier.height(24.dp))
 

--- a/app/src/main/java/com/example/bitacoradigital/ui/screens/auth/LoginScreen.kt
+++ b/app/src/main/java/com/example/bitacoradigital/ui/screens/auth/LoginScreen.kt
@@ -4,6 +4,8 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.background
 import androidx.compose.foundation.Image
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Login
@@ -43,12 +45,14 @@ fun LoginScreen(
     val loginState = loginViewModel.loginState
     val loading = loginViewModel.loading
     val snackbarHostState = remember { SnackbarHostState() }
+    val scrollState = rememberScrollState()
 
     Box(Modifier.fillMaxSize()) {
         Column(
             modifier = Modifier
                 .fillMaxSize()
-                .padding(horizontal = 32.dp),
+                .padding(horizontal = 32.dp)
+                .verticalScroll(scrollState),
             verticalArrangement = Arrangement.Center,
             horizontalAlignment = Alignment.CenterHorizontally
         ) {

--- a/app/src/main/java/com/example/bitacoradigital/ui/screens/auth/PasswordRequestScreen.kt
+++ b/app/src/main/java/com/example/bitacoradigital/ui/screens/auth/PasswordRequestScreen.kt
@@ -7,6 +7,8 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
@@ -25,11 +27,13 @@ fun PasswordRequestScreen(
 ) {
     var email by remember { mutableStateOf("") }
     val state = viewModel.state
+    val scrollState = rememberScrollState()
 
     Column(
         modifier = Modifier
             .fillMaxSize()
-            .padding(32.dp),
+            .padding(32.dp)
+            .verticalScroll(scrollState),
         verticalArrangement = Arrangement.Center,
         horizontalAlignment = Alignment.CenterHorizontally
     ) {

--- a/app/src/main/java/com/example/bitacoradigital/ui/screens/auth/PasswordResetScreen.kt
+++ b/app/src/main/java/com/example/bitacoradigital/ui/screens/auth/PasswordResetScreen.kt
@@ -1,6 +1,8 @@
 package com.example.bitacoradigital.ui.screens.auth
 
 import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Visibility
@@ -32,11 +34,13 @@ fun PasswordResetScreen(
     var showPassword by remember { mutableStateOf(false) }
     var localError by remember { mutableStateOf<String?>(null) }
     val state = viewModel.state
+    val scrollState = rememberScrollState()
 
     Column(
         modifier = Modifier
             .fillMaxSize()
-            .padding(32.dp),
+            .padding(32.dp)
+            .verticalScroll(scrollState),
         verticalArrangement = Arrangement.Center,
         horizontalAlignment = Alignment.CenterHorizontally
     ) {

--- a/app/src/main/java/com/example/bitacoradigital/ui/screens/auth/RegisterScreen.kt
+++ b/app/src/main/java/com/example/bitacoradigital/ui/screens/auth/RegisterScreen.kt
@@ -3,6 +3,8 @@ package com.example.bitacoradigital.ui.screens.auth
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.PersonAdd
@@ -29,11 +31,13 @@ fun RegisterScreen(
 
     var showPassword by remember { mutableStateOf(false) }
     var showConfirmPassword by remember { mutableStateOf(false) }
+    val scrollState = rememberScrollState()
 
     Column(
         modifier = Modifier
             .fillMaxSize()
-            .padding(horizontal = 32.dp),
+            .padding(horizontal = 32.dp)
+            .verticalScroll(scrollState),
         verticalArrangement = Arrangement.Center,
         horizontalAlignment = Alignment.CenterHorizontally
     ) {

--- a/app/src/main/java/com/example/bitacoradigital/ui/screens/auth/SignupScreen.kt
+++ b/app/src/main/java/com/example/bitacoradigital/ui/screens/auth/SignupScreen.kt
@@ -3,6 +3,8 @@ package com.example.bitacoradigital.ui.screens.auth
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.background
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.PersonAdd
@@ -38,12 +40,14 @@ fun SignupScreen(
     var showPassword by remember { mutableStateOf(false) }
     val state = signupViewModel.signupState
     val loading = signupViewModel.loading
+    val scrollState = rememberScrollState()
 
     Box(Modifier.fillMaxSize()) {
         Column(
             modifier = Modifier
                 .fillMaxSize()
-                .padding(horizontal = 32.dp),
+                .padding(horizontal = 32.dp)
+                .verticalScroll(scrollState),
             verticalArrangement = Arrangement.Center,
             horizontalAlignment = Alignment.CenterHorizontally
         ) {

--- a/app/src/main/java/com/example/bitacoradigital/ui/screens/auth/VerificationScreen.kt
+++ b/app/src/main/java/com/example/bitacoradigital/ui/screens/auth/VerificationScreen.kt
@@ -2,6 +2,8 @@ package com.example.bitacoradigital.ui.screens.auth
 
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.background
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
@@ -24,12 +26,14 @@ fun VerificationScreen(
     var code by remember { mutableStateOf("") }
     val state = signupViewModel.signupState
     val loading = signupViewModel.loading
+    val scrollState = rememberScrollState()
 
     Box(Modifier.fillMaxSize()) {
         Column(
             modifier = Modifier
                 .fillMaxSize()
-                .padding(32.dp),
+                .padding(32.dp)
+                .verticalScroll(scrollState),
             verticalArrangement = Arrangement.Center,
             horizontalAlignment = Alignment.CenterHorizontally
         ) {

--- a/app/src/main/java/com/example/bitacoradigital/ui/screens/qr/GenerarCodigoQRScreen.kt
+++ b/app/src/main/java/com/example/bitacoradigital/ui/screens/qr/GenerarCodigoQRScreen.kt
@@ -1,6 +1,8 @@
 package com.example.bitacoradigital.ui.screens.qr
 
 import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Button
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
@@ -29,6 +31,7 @@ fun GenerarCodigoQRScreen(navController: NavHostController) {
     val caducidad by viewModel.caducidad.collectAsState()
     val mensaje by viewModel.mensaje.collectAsState()
     val cargando by viewModel.cargando.collectAsState()
+    val scrollState = rememberScrollState()
 
     Scaffold(
         bottomBar = {
@@ -43,7 +46,8 @@ fun GenerarCodigoQRScreen(navController: NavHostController) {
         modifier = Modifier
             .fillMaxSize()
             .padding(innerPadding)
-            .padding(16.dp),
+            .padding(16.dp)
+            .verticalScroll(scrollState),
         verticalArrangement = Arrangement.spacedBy(16.dp, Alignment.CenterVertically),
         horizontalAlignment = Alignment.CenterHorizontally
     ) {

--- a/app/src/main/java/com/example/bitacoradigital/ui/screens/qr/SeguimientoQRScreen.kt
+++ b/app/src/main/java/com/example/bitacoradigital/ui/screens/qr/SeguimientoQRScreen.kt
@@ -43,6 +43,7 @@ fun SeguimientoQRScreen(
     val historial by viewModel.historial.collectAsState()
     val cargando by viewModel.cargando.collectAsState()
     val error by viewModel.error.collectAsState()
+    val scrollState = rememberScrollState()
 
     val puedeEliminar = "Eliminar Código QR" in permisos
     val puedeModificar = "Modificar Código QR" in permisos
@@ -80,7 +81,8 @@ fun SeguimientoQRScreen(
                 modifier = Modifier
                     .fillMaxSize()
                     .padding(innerPadding)
-                    .padding(horizontal = 16.dp),
+                    .padding(horizontal = 16.dp)
+                    .verticalScroll(scrollState),
                 verticalArrangement = Arrangement.spacedBy(16.dp),
                 horizontalAlignment = Alignment.CenterHorizontally
             ) {

--- a/app/src/main/java/com/example/bitacoradigital/ui/screens/registrovisita/PasoAutorizacion.kt
+++ b/app/src/main/java/com/example/bitacoradigital/ui/screens/registrovisita/PasoAutorizacion.kt
@@ -2,6 +2,8 @@ package com.example.bitacoradigital.ui.screens.registrovisita
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowDropDown
 import androidx.compose.material.icons.filled.ArrowDropUp
@@ -25,6 +27,7 @@ fun PasoAutorizacion(viewModel: RegistroVisitaViewModel) {
     val cargandoReg by viewModel.cargandoRegistro.collectAsState()
     val registroCompleto by viewModel.registroCompleto.collectAsState()
     val context = LocalContext.current
+    val scrollState = rememberScrollState()
 
     LaunchedEffect(destino) {
         destino?.let { viewModel.cargarResidentesDestino(it.perimetro_id) }
@@ -38,7 +41,12 @@ fun PasoAutorizacion(viewModel: RegistroVisitaViewModel) {
     val seleccionado = residentes.find { it.idPersona == invitanteId }
 
     Box(Modifier.fillMaxSize()) {
-        Column(modifier = Modifier.fillMaxSize().padding(16.dp)) {
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(16.dp)
+                .verticalScroll(scrollState)
+        ) {
             Text("Paso 7: ¿Quién autorizó?", style = MaterialTheme.typography.titleLarge)
             Spacer(Modifier.height(16.dp))
 

--- a/app/src/main/java/com/example/bitacoradigital/ui/screens/registrovisita/PasoConfirmacion.kt
+++ b/app/src/main/java/com/example/bitacoradigital/ui/screens/registrovisita/PasoConfirmacion.kt
@@ -4,6 +4,8 @@ package com.example.bitacoradigital.ui.screens.registrovisita
 import android.net.Uri
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -27,13 +29,17 @@ fun PasoConfirmacion(viewModel: RegistroVisitaViewModel) {
     val documento = viewModel.documentoUri.value
     val destino by viewModel.destinoSeleccionado.collectAsState()
     val fotos by viewModel.fotosAdicionales.collectAsState()
+    val scrollState = rememberScrollState()
 
 
 
     Box(Modifier.fillMaxSize()) {
-        Column(modifier = Modifier
-            .fillMaxSize()
-            .padding(16.dp)) {
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(16.dp)
+                .verticalScroll(scrollState)
+        ) {
 
         Text("Paso 6: Confirma tu Registro", style = MaterialTheme.typography.titleLarge)
         Spacer(Modifier.height(16.dp))

--- a/app/src/main/java/com/example/bitacoradigital/ui/screens/registrovisita/PasoDestino.kt
+++ b/app/src/main/java/com/example/bitacoradigital/ui/screens/registrovisita/PasoDestino.kt
@@ -2,6 +2,8 @@
 package com.example.bitacoradigital.ui.screens.registrovisita
 
 import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
@@ -21,6 +23,7 @@ fun PasoDestino(viewModel: RegistroVisitaViewModel) {
     val cargando by viewModel.cargandoDestino.collectAsState()
     val error by viewModel.errorDestino.collectAsState()
     val snackbarHostState = remember { SnackbarHostState() }
+    val scrollState = rememberScrollState()
 
     LaunchedEffect(Unit) {
         viewModel.cargarJerarquiaDestino()
@@ -32,6 +35,7 @@ fun PasoDestino(viewModel: RegistroVisitaViewModel) {
         modifier = Modifier
             .fillMaxSize()
             .padding(16.dp)
+            .verticalScroll(scrollState)
     ) {
         Text("Paso 4: Selección de Destino", style = MaterialTheme.typography.titleLarge)
         Spacer(modifier = Modifier.height(16.dp))

--- a/app/src/main/java/com/example/bitacoradigital/ui/screens/registrovisita/PasoDocumento.kt
+++ b/app/src/main/java/com/example/bitacoradigital/ui/screens/registrovisita/PasoDocumento.kt
@@ -13,6 +13,8 @@ import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.fadeIn
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.CameraAlt
@@ -41,6 +43,7 @@ fun PasoDocumento(viewModel: RegistroVisitaViewModel) {
     val error by viewModel.errorReconocimiento.collectAsState()
     val snackbarHostState = remember { SnackbarHostState() }
     val coroutineScope = rememberCoroutineScope()
+    val scrollState = rememberScrollState()
 
     var hasCameraPermission by remember {
         mutableStateOf(
@@ -81,7 +84,8 @@ fun PasoDocumento(viewModel: RegistroVisitaViewModel) {
         Column(
             modifier = Modifier
                 .fillMaxSize()
-                .padding(24.dp),
+                .padding(24.dp)
+                .verticalScroll(scrollState),
             horizontalAlignment = Alignment.CenterHorizontally,
             verticalArrangement = Arrangement.Center
         ) {

--- a/app/src/main/java/com/example/bitacoradigital/ui/screens/registrovisita/PasoFinal.kt
+++ b/app/src/main/java/com/example/bitacoradigital/ui/screens/registrovisita/PasoFinal.kt
@@ -2,6 +2,8 @@
 package com.example.bitacoradigital.ui.screens.registrovisita
 
 import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.foundation.Image
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
@@ -23,10 +25,12 @@ fun PasoFinal(viewModel: RegistroVisitaViewModel, navController: NavHostControll
     val respuesta by viewModel.respuestaRegistro.collectAsState()
     val qrBitmap by viewModel.qrBitmap.collectAsState()
     val context = LocalContext.current
+    val scrollState = rememberScrollState()
     Column(
         modifier = Modifier
             .fillMaxSize()
-            .padding(24.dp),
+            .padding(24.dp)
+            .verticalScroll(scrollState),
         verticalArrangement = Arrangement.Center,
         horizontalAlignment = Alignment.CenterHorizontally
     ) {

--- a/app/src/main/java/com/example/bitacoradigital/ui/screens/registrovisita/PasoFotos.kt
+++ b/app/src/main/java/com/example/bitacoradigital/ui/screens/registrovisita/PasoFotos.kt
@@ -5,6 +5,8 @@ import androidx.activity.result.contract.ActivityResultContracts
 import android.Manifest
 import android.content.pm.PackageManager
 import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
@@ -45,6 +47,7 @@ import kotlinx.coroutines.launch
 fun PasoFotos(viewModel: RegistroVisitaViewModel) {
     val fotos by viewModel.fotosAdicionales.collectAsState()
     val context = LocalContext.current
+    val scrollState = rememberScrollState()
 
     var hasCameraPermission by remember {
         mutableStateOf(
@@ -78,7 +81,12 @@ fun PasoFotos(viewModel: RegistroVisitaViewModel) {
         onResult = { success -> if (success) tempUri?.let { viewModel.agregarFoto(it) } }
     )
 
-    Column(Modifier.fillMaxSize().padding(16.dp)) {
+    Column(
+        Modifier
+            .fillMaxSize()
+            .padding(16.dp)
+            .verticalScroll(scrollState)
+    ) {
         Text("Paso 5: Fotos adicionales", style = MaterialTheme.typography.titleLarge)
         Spacer(Modifier.height(16.dp))
 

--- a/app/src/main/java/com/example/bitacoradigital/ui/screens/registrovisita/PasoTelefono.kt
+++ b/app/src/main/java/com/example/bitacoradigital/ui/screens/registrovisita/PasoTelefono.kt
@@ -2,6 +2,8 @@
 package com.example.bitacoradigital.ui.screens.registrovisita
 
 import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
@@ -24,13 +26,15 @@ fun PasoTelefono(viewModel: RegistroVisitaViewModel) {
     val snackbarHostState = remember { SnackbarHostState() }
 
     val coroutineScope = rememberCoroutineScope()
+    val scrollState = rememberScrollState()
 
     Box(Modifier.fillMaxSize()) {
         Column(
             modifier = Modifier
                 .align(Alignment.Center)
                 .fillMaxWidth()
-                .padding(16.dp),
+                .padding(16.dp)
+                .verticalScroll(scrollState),
             horizontalAlignment = Alignment.CenterHorizontally
         ) {
 

--- a/app/src/main/java/com/example/bitacoradigital/ui/screens/registrovisita/PasoVerificacion.kt
+++ b/app/src/main/java/com/example/bitacoradigital/ui/screens/registrovisita/PasoVerificacion.kt
@@ -3,6 +3,8 @@
 package com.example.bitacoradigital.ui.screens.registrovisita
 
 import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Edit
@@ -24,6 +26,7 @@ fun PasoVerificacion(viewModel: RegistroVisitaViewModel) {
     var nuevoNombre by remember { mutableStateOf(nombre) }
     var nuevoApellidoPat by remember { mutableStateOf(apellidoPaterno) }
     var nuevoApellidoMat by remember { mutableStateOf(apellidoMaterno) }
+    val scrollState = rememberScrollState()
 
     Box(
         modifier = Modifier
@@ -31,7 +34,10 @@ fun PasoVerificacion(viewModel: RegistroVisitaViewModel) {
             .padding(16.dp),
         contentAlignment = Alignment.Center
     ) {
-        Column(horizontalAlignment = Alignment.CenterHorizontally) {
+        Column(
+            modifier = Modifier.verticalScroll(scrollState),
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
             Text("Paso 3: Verifica tus Datos", style = MaterialTheme.typography.titleLarge)
             Spacer(Modifier.height(16.dp))
 


### PR DESCRIPTION
## Summary
- improve responsiveness of many Compose screens
- add scroll state and vertical scrolling where necessary

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a43495eac832fa84a43adc06ee18c