### PR TITLE
Add privacy notice dialog and link

### DIFF
--- a/app/src/main/java/com/example/bitacoradigital/ui/screens/ConfiguracionScreen.kt
+++ b/app/src/main/java/com/example/bitacoradigital/ui/screens/ConfiguracionScreen.kt
@@ -3,6 +3,7 @@ package com.example.bitacoradigital.ui.screens
 
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.foundation.clickable
 import androidx.compose.material3.*
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Edit
@@ -28,6 +29,7 @@ import kotlinx.coroutines.withContext
 import com.example.bitacoradigital.viewmodel.SessionViewModel
 import kotlinx.coroutines.launch
 import com.example.bitacoradigital.ui.components.HomeConfigNavBar
+import androidx.compose.ui.platform.LocalUriHandler
 
 @Composable
 fun ConfiguracionScreen(
@@ -46,6 +48,7 @@ fun ConfiguracionScreen(
     var logoutConfirm by remember { mutableStateOf(false) }
     var updateMsg by remember { mutableStateOf<String?>(null) }
     val coroutineScope = rememberCoroutineScope()
+    val uriHandler = LocalUriHandler.current
 
     val hayCambios = usuario != null && (
         nombre != (usuario?.nombre ?: "") ||
@@ -149,6 +152,14 @@ fun ConfiguracionScreen(
                     Spacer(Modifier.width(8.dp))
                     Text("Restablecer contraseña")
                 }
+
+                Text(
+                    text = "Consulta nuestro aviso de privacidad",
+                    modifier = Modifier
+                        .clickable { uriHandler.openUri("https://bit.cs3.mx/aviso-privacidad") }
+                        .padding(top = 8.dp),
+                    color = MaterialTheme.colorScheme.primary
+                )
 
                 Spacer(modifier = Modifier.height(16.dp))
                 Divider()

--- a/app/src/main/java/com/example/bitacoradigital/ui/screens/auth/LoginScreen.kt
+++ b/app/src/main/java/com/example/bitacoradigital/ui/screens/auth/LoginScreen.kt
@@ -23,6 +23,7 @@ import com.example.bitacoradigital.viewmodel.LoginViewModel
 import com.example.bitacoradigital.viewmodel.SessionViewModel
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
+import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.res.painterResource
 import com.example.bitacoradigital.R
 
@@ -46,6 +47,8 @@ fun LoginScreen(
     val loading = loginViewModel.loading
     val snackbarHostState = remember { SnackbarHostState() }
     val scrollState = rememberScrollState()
+    var showPrivacyDialog by remember { mutableStateOf(true) }
+    val uriHandler = LocalUriHandler.current
 
     Box(Modifier.fillMaxSize()) {
         Column(
@@ -165,6 +168,20 @@ fun LoginScreen(
             ) {
                 CircularProgressIndicator()
             }
+        }
+
+        if (showPrivacyDialog) {
+            AlertDialog(
+                onDismissRequest = { showPrivacyDialog = false },
+                confirmButton = {
+                    TextButton(onClick = { showPrivacyDialog = false }) { Text("Continuar") }
+                },
+                text = {
+                    TextButton(onClick = { uriHandler.openUri("https://bit.cs3.mx/aviso-privacidad") }) {
+                        Text("Consultar aviso de privacidad")
+                    }
+                }
+            )
         }
     }
 }


### PR DESCRIPTION
## Summary
- pop up a privacy-policy dialog when the login screen opens
- link to privacy policy from the config screen

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_685abf05e328832fbe5bbce9b73264e1