### PR TITLE
Fix version check uses BuildConfig

### DIFF
--- a/app/src/main/java/com/example/bitacoradigital/util/Constants.kt
+++ b/app/src/main/java/com/example/bitacoradigital/util/Constants.kt
@@ -1,11 +1,18 @@
 package com.example.bitacoradigital.util
 
+import com.example.bitacoradigital.BuildConfig
 import java.text.SimpleDateFormat
 import java.util.*
 
 object Constants {
     const val FILE_PROVIDER_AUTHORITY: String = "com.example.bitacoradigital.fileprovider"
-    const val APP_VERSION: String = "1.0.1"
+    /**
+     * Current application version as declared in Gradle.
+     * This uses [BuildConfig.VERSION_NAME] so bumping `versionName`
+     * automatically updates the check against the API without
+     * requiring a manual constant edit.
+     */
+    val APP_VERSION: String = BuildConfig.VERSION_NAME
 }
 
 fun Long.toReadableDate(): String {


### PR DESCRIPTION
## Summary
- use `BuildConfig.VERSION_NAME` for automatic version comparisons

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ccd8b99d4832fa590de1a402a0028