### PR TITLE
Implement version mismatch redirect on session refresh

### DIFF
--- a/app/src/main/java/com/example/bitacoradigital/navigation/NavGraph.kt
+++ b/app/src/main/java/com/example/bitacoradigital/navigation/NavGraph.kt
@@ -7,6 +7,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
+import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
@@ -51,6 +52,15 @@ fun AppNavGraph(
 
     val tieneAcceso by sessionViewModel.tieneAccesoABitacora.collectAsState()
     val versionOk by sessionViewModel.versionOk.collectAsState()
+    val backStackEntry by navController.currentBackStackEntryAsState()
+
+    LaunchedEffect(versionOk) {
+        if (versionOk == false && backStackEntry?.destination?.route != "update") {
+            navController.navigate("update") {
+                popUpTo("update") { inclusive = true }
+            }
+        }
+    }
 
     val startDestination = when {
         versionOk == false -> "update"


### PR DESCRIPTION
## Summary
- observe session version state and navigate to update screen when it becomes outdated

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_685cd3515be0832f8e0965f928d29652