### PR TITLE
Fix version check on login

### DIFF
--- a/app/src/main/java/com/example/bitacoradigital/util/Constants.kt
+++ b/app/src/main/java/com/example/bitacoradigital/util/Constants.kt
@@ -1,11 +1,18 @@
 package com.example.bitacoradigital.util
 
+import com.example.bitacoradigital.BuildConfig
 import java.text.SimpleDateFormat
 import java.util.*
 
 object Constants {
     const val FILE_PROVIDER_AUTHORITY: String = "com.example.bitacoradigital.fileprovider"
-    const val APP_VERSION: String = "1.0.1"
+
+    /**
+     * Current application version as declared in Gradle.
+     * Uses [BuildConfig.VERSION_NAME] so updating `versionName`
+     * automatically adjusts the API comparison without manual edits.
+     */
+    val APP_VERSION: String = BuildConfig.VERSION_NAME
 }
 
 fun Long.toReadableDate(): String {


### PR DESCRIPTION
## Summary
- read app version from BuildConfig again so login verification works

## Testing
- `./gradlew test --info` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_685cd82197c0832fbf07afa1e07516da