### PR TITLE
Add DronGuard panic module

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -78,6 +78,7 @@ dependencies {
     implementation("androidx.camera:camera-lifecycle:1.3.2")
     implementation("androidx.camera:camera-view:1.3.2")
     implementation("com.google.mlkit:barcode-scanning:17.2.0")
+    implementation("com.google.android.gms:play-services-location:21.0.1")
     testImplementation("junit:junit:4.13.2")
     androidTestImplementation("androidx.test.ext:junit:1.2.1")
     androidTestImplementation("androidx.test.espresso:espresso-core:3.6.1")

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -42,6 +42,7 @@
     </application>
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.CAMERA" />
+    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
 
 
 </manifest>

--- a/app/src/main/java/com/example/bitacoradigital/data/SessionPreferences.kt
+++ b/app/src/main/java/com/example/bitacoradigital/data/SessionPreferences.kt
@@ -16,6 +16,7 @@ object SessionKeys {
     val FAVORITO_PERIMETRO_ID = intPreferencesKey("favorito_perimetro_id")
     val JSON_SESSION = stringPreferencesKey("json_session") // ✅ nuevo
     val VERSION = stringPreferencesKey("version")
+    val UUID_BOTON = stringPreferencesKey("uuid_boton")
 }
 
 class SessionPreferences(private val context: Context) {
@@ -27,6 +28,7 @@ class SessionPreferences(private val context: Context) {
     val favoritoPerimetroId: Flow<Int?> = context.dataStore.data.map { it[SessionKeys.FAVORITO_PERIMETRO_ID] }
     val jsonSession: Flow<String?> = context.dataStore.data.map { it[SessionKeys.JSON_SESSION] } // ✅ nuevo
     val version: Flow<String?> = context.dataStore.data.map { it[SessionKeys.VERSION] }
+    val uuidBoton: Flow<String?> = context.dataStore.data.map { it[SessionKeys.UUID_BOTON] }
 
     suspend fun guardarSesion(token: String, userId: Int, personaId: Int, json: String, version: String) {
         context.dataStore.edit { prefs ->
@@ -43,6 +45,12 @@ class SessionPreferences(private val context: Context) {
         context.dataStore.edit { prefs ->
             prefs[SessionKeys.FAVORITO_EMPRESA_ID] = empresaId
             prefs[SessionKeys.FAVORITO_PERIMETRO_ID] = perimetroId
+        }
+    }
+
+    suspend fun guardarUuidBoton(uuid: String) {
+        context.dataStore.edit { prefs ->
+            prefs[SessionKeys.UUID_BOTON] = uuid
         }
     }
 

--- a/app/src/main/java/com/example/bitacoradigital/navigation/NavGraph.kt
+++ b/app/src/main/java/com/example/bitacoradigital/navigation/NavGraph.kt
@@ -28,11 +28,14 @@ import com.example.bitacoradigital.ui.screens.qr.SeguimientoQRScreen
 import com.example.bitacoradigital.ui.screens.dashboard.DashboardScreen
 import com.example.bitacoradigital.ui.screens.accesos.AccesosScreen
 import com.example.bitacoradigital.ui.screens.residentes.ResidentesScreen
+import com.example.bitacoradigital.ui.screens.guardia.DronGuardScreen
 import com.example.bitacoradigital.viewmodel.HomeViewModel
 import com.example.bitacoradigital.viewmodel.LoginViewModel
 import com.example.bitacoradigital.viewmodel.SessionViewModel
 import com.example.bitacoradigital.viewmodel.SignupViewModel
 import com.example.bitacoradigital.viewmodel.ForgotPasswordViewModel
+import com.example.bitacoradigital.viewmodel.DronGuardViewModel
+import androidx.compose.ui.platform.LocalContext
 
 
 @Composable
@@ -207,6 +210,13 @@ fun AppNavGraph(
                 homeViewModel = homeViewModel,
                 navController = navController
             )
+        }
+
+        composable("dronguard") {
+            val context = LocalContext.current
+            val prefs = remember { SessionPreferences(context) }
+            val viewModel: DronGuardViewModel = viewModel(factory = DronGuardViewModel.Factory(prefs))
+            DronGuardScreen(viewModel = viewModel, navController = navController)
         }
 
 

--- a/app/src/main/java/com/example/bitacoradigital/ui/components/menu/ModuleButton.kt
+++ b/app/src/main/java/com/example/bitacoradigital/ui/components/menu/ModuleButton.kt
@@ -16,6 +16,7 @@ import androidx.compose.material.icons.filled.ListAlt
 import androidx.compose.material.icons.filled.Map
 import androidx.compose.material.icons.filled.People
 import androidx.compose.material.icons.filled.QrCode
+import androidx.compose.material.icons.filled.Warning
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.Icon
@@ -71,5 +72,6 @@ fun moduloIcon(nombre: String): ImageVector = when (nombre) {
     "Administración de Usuarios" -> Icons.Default.Group
     "Registros de Visitas" -> Icons.Default.ListAlt
     "Accesos" -> Icons.Default.DirectionsCar
+    "DronGuard" -> Icons.Default.Warning
     else -> Icons.Default.Dashboard
 }

--- a/app/src/main/java/com/example/bitacoradigital/ui/screens/HomeScreen.kt
+++ b/app/src/main/java/com/example/bitacoradigital/ui/screens/HomeScreen.kt
@@ -91,7 +91,7 @@ fun HomeScreen(
 
                 val perimetroMods = listOf("Dashboard", "Perímetro", "Residentes", "Accesos")
                 val accesoMods = listOf("Códigos QR", "Registros de Visitas")
-                val guardiaMods = listOf("Guardia")
+                val guardiaMods = listOf("Guardia", "DronGuard")
                 val novedadesMods = listOf("Novedades")
 
                 val modulosVisibles = activo.modulos.keys.filterNot { it in ocultos }
@@ -175,6 +175,7 @@ fun HomeScreen(
                                     ModuleButton(title = modulo, icon = icon) {
                                         when (modulo) {
                                             "Guardia" -> navController.navigate("guardia")
+                                            "DronGuard" -> navController.navigate("dronguard")
                                             else -> {}
                                         }
                                     }

--- a/app/src/main/java/com/example/bitacoradigital/ui/screens/guardia/DronGuardScreen.kt
+++ b/app/src/main/java/com/example/bitacoradigital/ui/screens/guardia/DronGuardScreen.kt
@@ -1,0 +1,70 @@
+package com.example.bitacoradigital.ui.screens.guardia
+
+import android.Manifest
+import android.content.pm.PackageManager
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.interaction.collectIsPressedAsState
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.unit.dp
+import androidx.core.app.ActivityCompat
+import androidx.navigation.NavHostController
+import com.example.bitacoradigital.viewmodel.DronGuardViewModel
+import com.google.android.gms.location.LocationServices
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+
+@Composable
+fun DronGuardScreen(viewModel: DronGuardViewModel, navController: NavHostController) {
+    val context = LocalContext.current
+    val fused = remember { LocationServices.getFusedLocationProviderClient(context) }
+    val permissionLauncher = rememberLauncherForActivityResult(ActivityResultContracts.RequestPermission()) {}
+    val scope = rememberCoroutineScope()
+
+    var job by remember { mutableStateOf<Job?>(null) }
+    val interaction = remember { MutableInteractionSource() }
+    val pressed by interaction.collectIsPressedAsState()
+
+    LaunchedEffect(pressed) {
+        if (pressed) {
+            job = scope.launch {
+                delay(3000)
+                if (pressed) {
+                    if (ActivityCompat.checkSelfPermission(context, Manifest.permission.ACCESS_FINE_LOCATION) != PackageManager.PERMISSION_GRANTED) {
+                        permissionLauncher.launch(Manifest.permission.ACCESS_FINE_LOCATION)
+                        return@launch
+                    }
+                    fused.lastLocation.addOnSuccessListener { loc ->
+                        loc?.let { viewModel.enviarAlerta(it.latitude, it.longitude) }
+                    }
+                }
+            }
+        } else {
+            job?.cancel(); job = null
+        }
+    }
+
+    Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+        Button(
+            onClick = {},
+            modifier = Modifier.size(200.dp),
+            interactionSource = interaction,
+            colors = ButtonDefaults.buttonColors(containerColor = Color.Red)
+        ) {
+            Text("SOS", color = MaterialTheme.colorScheme.onPrimary)
+        }
+    }
+}

--- a/app/src/main/java/com/example/bitacoradigital/util/Constants.kt
+++ b/app/src/main/java/com/example/bitacoradigital/util/Constants.kt
@@ -8,6 +8,9 @@ object Constants {
 
 
     val APP_VERSION: String = "1.0.1"
+    const val DRON_GUARD_TOKEN: String = "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmcmVzaCI6ZmFsc2UsImlhdCI6MTc1MjI1MzYyMiwianRpIjoiNWJhOGY1MTQtYWM4OC00ZDVjLTkwMjQtOWY5OGZkM2U2NDA3IiwidHlwZSI6ImFjY2VzcyIsInN1YiI6Ik9QRVJBRE9SIiwibmJmIjoxNzUyMjUzNjIyLCJjc3JmIjoiNmRiM2E1NWYtY2QyOC00NTNkLWFkZmItY2I5ZTc0ZmUzZTM5IiwiZXhwIjoxNzgzNzg5NjIyfQ.NPAuRWCPVOdLNWx5C9K-dEzwdLAsP6WC5V8P4zdYNC0"
+    const val DRON_GUARD_REGISTRO: String = "https://ubicua.earthnergy.com/boton/v1.0/registro"
+    const val DRON_GUARD_SEND: String = "https://ubicua.earthnergy.com/boton/v1.0/send"
 }
 
 fun Long.toReadableDate(): String {

--- a/app/src/main/java/com/example/bitacoradigital/viewmodel/DronGuardViewModel.kt
+++ b/app/src/main/java/com/example/bitacoradigital/viewmodel/DronGuardViewModel.kt
@@ -1,0 +1,54 @@
+package com.example.bitacoradigital.viewmodel
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.viewModelScope
+import com.example.bitacoradigital.data.SessionPreferences
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.RequestBody.Companion.toRequestBody
+import org.json.JSONObject
+
+class DronGuardViewModel(private val prefs: SessionPreferences) : ViewModel() {
+
+    val uuid: StateFlow<String?> = prefs.uuidBoton.stateIn(viewModelScope, kotlinx.coroutines.flow.SharingStarted.Lazily, null)
+
+    private val client = OkHttpClient()
+
+    fun enviarAlerta(lat: Double, lng: Double) {
+        viewModelScope.launch {
+            val id = uuid.value ?: return@launch
+            try {
+                val bodyJson = JSONObject().apply {
+                    put("uuid_usuario", id)
+                    put("lat", lat.toString())
+                    put("lng", lng.toString())
+                }
+                val body = bodyJson.toString().toRequestBody("application/json".toMediaType())
+                val request = Request.Builder()
+                    .url(com.example.bitacoradigital.util.Constants.DRON_GUARD_SEND)
+                    .post(body)
+                    .addHeader("X-Authorization", com.example.bitacoradigital.util.Constants.DRON_GUARD_TOKEN)
+                    .addHeader("Content-Type", "application/json")
+                    .build()
+                withContext(Dispatchers.IO) { client.newCall(request).execute().close() }
+            } catch (_: Exception) { }
+        }
+    }
+
+    class Factory(private val prefs: SessionPreferences) : ViewModelProvider.Factory {
+        override fun <T : ViewModel> create(modelClass: Class<T>): T {
+            if (modelClass.isAssignableFrom(DronGuardViewModel::class.java)) {
+                @Suppress("UNCHECKED_CAST")
+                return DronGuardViewModel(prefs) as T
+            }
+            throw IllegalArgumentException("Unknown ViewModel class")
+        }
+    }
+}

--- a/app/src/main/java/com/example/bitacoradigital/viewmodel/LoginViewModel.kt
+++ b/app/src/main/java/com/example/bitacoradigital/viewmodel/LoginViewModel.kt
@@ -49,6 +49,7 @@ class LoginViewModel : ViewModel() {
 
                 if (user.empresas.any { it.B }) {
                     sessionViewModel.guardarSesion(token, user)
+                    sessionViewModel.registrarBotonPanico()
                     if (user.Version == com.example.bitacoradigital.util.Constants.APP_VERSION) {
                         loginState = "Login exitoso"
                         onLoginSuccess()


### PR DESCRIPTION
## Summary
- add dependency for location services
- store DronGuard uuid in session prefs
- add constants and API calls for DronGuard
- create DronGuardViewModel and screen with panic button
- show new module in home menu and navigation
- request location permission and send alert

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_687575e458fc832f86df9dbe2c8ceba5