### PR TITLE
Add panic button animation and response logs

### DIFF
--- a/app/src/main/java/com/example/bitacoradigital/ui/screens/guardia/DronGuardScreen.kt
+++ b/app/src/main/java/com/example/bitacoradigital/ui/screens/guardia/DronGuardScreen.kt
@@ -4,11 +4,12 @@ import android.Manifest
 import android.content.pm.PackageManager
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.animation.core.Animatable
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.background
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.interaction.collectIsPressedAsState
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.*
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.MaterialTheme
@@ -18,6 +19,8 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.core.app.ActivityCompat
 import androidx.navigation.NavHostController
@@ -34,37 +37,60 @@ fun DronGuardScreen(viewModel: DronGuardViewModel, navController: NavHostControl
     val permissionLauncher = rememberLauncherForActivityResult(ActivityResultContracts.RequestPermission()) {}
     val scope = rememberCoroutineScope()
 
-    var job by remember { mutableStateOf<Job?>(null) }
+    var showMessage by remember { mutableStateOf(false) }
     val interaction = remember { MutableInteractionSource() }
     val pressed by interaction.collectIsPressedAsState()
+    val sizeAnim = remember { Animatable(200.dp, Dp.VectorConverter) }
 
     LaunchedEffect(pressed) {
-        if (pressed) {
-            job = scope.launch {
-                delay(3000)
-                if (pressed) {
-                    if (ActivityCompat.checkSelfPermission(context, Manifest.permission.ACCESS_FINE_LOCATION) != PackageManager.PERMISSION_GRANTED) {
-                        permissionLauncher.launch(Manifest.permission.ACCESS_FINE_LOCATION)
-                        return@launch
-                    }
+        if (pressed && !showMessage) {
+            sizeAnim.snapTo(200.dp)
+            sizeAnim.animateTo(600.dp, tween(3000))
+            if (pressed) {
+                if (ActivityCompat.checkSelfPermission(context, Manifest.permission.ACCESS_FINE_LOCATION) != PackageManager.PERMISSION_GRANTED) {
+                    permissionLauncher.launch(Manifest.permission.ACCESS_FINE_LOCATION)
+                } else {
                     fused.lastLocation.addOnSuccessListener { loc ->
                         loc?.let { viewModel.enviarAlerta(it.latitude, it.longitude) }
                     }
                 }
+                showMessage = true
             }
-        } else {
-            job?.cancel(); job = null
+        } else if (!pressed && !showMessage) {
+            sizeAnim.snapTo(200.dp)
         }
     }
 
-    Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-        Button(
-            onClick = {},
-            modifier = Modifier.size(200.dp),
-            interactionSource = interaction,
-            colors = ButtonDefaults.buttonColors(containerColor = Color.Red)
+    if (showMessage) {
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .background(Color.Red),
+            contentAlignment = Alignment.Center
         ) {
-            Text("SOS", color = MaterialTheme.colorScheme.onPrimary)
+            Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                Text(
+                    "Dron desplegado a tu ubicacion",
+                    color = Color.White,
+                    textAlign = TextAlign.Center,
+                    style = MaterialTheme.typography.headlineSmall
+                )
+                Spacer(Modifier.height(24.dp))
+                Button(onClick = { navController.navigate("home") }) {
+                    Text("Volver a pantalla principal")
+                }
+            }
+        }
+    } else {
+        Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+            Button(
+                onClick = {},
+                modifier = Modifier.size(sizeAnim.value),
+                interactionSource = interaction,
+                colors = ButtonDefaults.buttonColors(containerColor = Color.Red)
+            ) {
+                Text("SOS", color = MaterialTheme.colorScheme.onPrimary)
+            }
         }
     }
 }

--- a/app/src/main/java/com/example/bitacoradigital/viewmodel/DronGuardViewModel.kt
+++ b/app/src/main/java/com/example/bitacoradigital/viewmodel/DronGuardViewModel.kt
@@ -9,6 +9,7 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import android.util.Log
 import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.OkHttpClient
 import okhttp3.Request
@@ -37,7 +38,10 @@ class DronGuardViewModel(private val prefs: SessionPreferences) : ViewModel() {
                     .addHeader("X-Authorization", com.example.bitacoradigital.util.Constants.DRON_GUARD_TOKEN)
                     .addHeader("Content-Type", "application/json")
                     .build()
-                withContext(Dispatchers.IO) { client.newCall(request).execute().close() }
+                val response = withContext(Dispatchers.IO) { client.newCall(request).execute() }
+                val respBody = response.body?.string()
+                Log.d("DronGuard", "Response code: ${'$'}{response.code} body: ${'$'}respBody")
+                response.close()
             } catch (_: Exception) { }
         }
     }


### PR DESCRIPTION
## Summary
- make panic button grow while pressed for 3 seconds
- display confirmation screen after alert is sent
- log server response when sending alert

## Testing
- `./gradlew build` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68758085b070832f92644b7bb2fa94b1