### PR TITLE
Improve DronGuard logging

### DIFF
--- a/app/src/main/java/com/example/bitacoradigital/ui/screens/guardia/DronGuardScreen.kt
+++ b/app/src/main/java/com/example/bitacoradigital/ui/screens/guardia/DronGuardScreen.kt
@@ -26,6 +26,7 @@ import androidx.core.app.ActivityCompat
 import androidx.navigation.NavHostController
 import com.example.bitacoradigital.viewmodel.DronGuardViewModel
 import com.google.android.gms.location.LocationServices
+import android.util.Log
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
@@ -44,13 +45,16 @@ fun DronGuardScreen(viewModel: DronGuardViewModel, navController: NavHostControl
 
     LaunchedEffect(pressed) {
         if (pressed && !showMessage) {
+            Log.d("DronGuardScreen", "Bot\u00f3n presionado")
             sizeAnim.snapTo(200.dp)
             sizeAnim.animateTo(600.dp, tween(3000))
             if (pressed) {
+                Log.d("DronGuardScreen", "Presionado 3s, enviando alerta")
                 if (ActivityCompat.checkSelfPermission(context, Manifest.permission.ACCESS_FINE_LOCATION) != PackageManager.PERMISSION_GRANTED) {
                     permissionLauncher.launch(Manifest.permission.ACCESS_FINE_LOCATION)
                 } else {
                     fused.lastLocation.addOnSuccessListener { loc ->
+                        Log.d("DronGuardScreen", "Ubicaci\u00f3n obtenida: ${'$'}loc")
                         loc?.let { viewModel.enviarAlerta(it.latitude, it.longitude) }
                     }
                 }

--- a/app/src/main/java/com/example/bitacoradigital/viewmodel/DronGuardViewModel.kt
+++ b/app/src/main/java/com/example/bitacoradigital/viewmodel/DronGuardViewModel.kt
@@ -31,6 +31,8 @@ class DronGuardViewModel(private val prefs: SessionPreferences) : ViewModel() {
                     put("lat", lat.toString())
                     put("lng", lng.toString())
                 }
+                Log.d("DronGuard", "Enviando alerta uuid=$id lat=$lat lng=$lng")
+
                 val body = bodyJson.toString().toRequestBody("application/json".toMediaType())
                 val request = Request.Builder()
                     .url(com.example.bitacoradigital.util.Constants.DRON_GUARD_SEND)
@@ -38,11 +40,14 @@ class DronGuardViewModel(private val prefs: SessionPreferences) : ViewModel() {
                     .addHeader("X-Authorization", com.example.bitacoradigital.util.Constants.DRON_GUARD_TOKEN)
                     .addHeader("Content-Type", "application/json")
                     .build()
+
                 val response = withContext(Dispatchers.IO) { client.newCall(request).execute() }
                 val respBody = response.body?.string()
                 Log.d("DronGuard", "Response code: ${'$'}{response.code} body: ${'$'}respBody")
                 response.close()
-            } catch (_: Exception) { }
+            } catch (e: Exception) {
+                Log.e("DronGuard", "Error enviando alerta", e)
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
- log when panic button is pressed and send alert
- log errors when sending alert fails

## Testing
- `./gradlew test --continue` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_687587d5838c832faeacc4d7cf268998