### PR TITLE
Ensure panic button uuid is fetched on session restore

### DIFF
--- a/app/src/main/java/com/example/bitacoradigital/viewmodel/SessionViewModel.kt
+++ b/app/src/main/java/com/example/bitacoradigital/viewmodel/SessionViewModel.kt
@@ -65,6 +65,7 @@ class SessionViewModel(application: Application) : AndroidViewModel(application)
                             _usuario.value = user
                             _tieneAccesoABitacora.value = acceso
                             _versionOk.value = null
+                            registrarBotonPanico()
                         } catch (e: Exception) {
                             // No cerrar sesión si falla el parseo, solo informar
                             Log.e("SessionViewModel", "Error al deserializar sesión", e)
@@ -106,11 +107,14 @@ class SessionViewModel(application: Application) : AndroidViewModel(application)
         _tieneAccesoABitacora.value = tieneAcceso
         _versionOk.value = user.Version == com.example.bitacoradigital.util.Constants.APP_VERSION
         prefs.guardarSesion(token, user.id, user.persona_id, gson.toJson(user), user.Version)
+        registrarBotonPanico()
     }
 
     fun registrarBotonPanico() {
         viewModelScope.launch {
             try {
+                val existing = prefs.uuidBoton.first()
+                if (!existing.isNullOrBlank()) return@launch
                 val bodyJson = JSONObject().apply {
                     put("nombre", "javier")
                     put("apellido_paterno", "fernandez")


### PR DESCRIPTION
## Summary
- register panic button uuid when restoring or saving a session
- avoid repeated registration calls if uuid already exists

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68758cb9b678832fb0a005787e4a9e37