### PR TITLE
Register panic button uuid on module entry

### DIFF
--- a/app/src/main/java/com/example/bitacoradigital/ui/screens/guardia/DronGuardScreen.kt
+++ b/app/src/main/java/com/example/bitacoradigital/ui/screens/guardia/DronGuardScreen.kt
@@ -43,6 +43,10 @@ fun DronGuardScreen(viewModel: DronGuardViewModel, navController: NavHostControl
     val pressed by interaction.collectIsPressedAsState()
     val sizeAnim = remember { Animatable(200.dp, Dp.VectorConverter) }
 
+    LaunchedEffect(Unit) {
+        viewModel.registrarBotonPanico()
+    }
+
     LaunchedEffect(pressed) {
         if (pressed && !showMessage) {
             Log.d("DronGuardScreen", "Bot\u00f3n presionado")

--- a/app/src/main/java/com/example/bitacoradigital/viewmodel/DronGuardViewModel.kt
+++ b/app/src/main/java/com/example/bitacoradigital/viewmodel/DronGuardViewModel.kt
@@ -7,6 +7,7 @@ import com.example.bitacoradigital.data.SessionPreferences
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import android.util.Log
@@ -21,6 +22,61 @@ class DronGuardViewModel(private val prefs: SessionPreferences) : ViewModel() {
     val uuid: StateFlow<String?> = prefs.uuidBoton.stateIn(viewModelScope, kotlinx.coroutines.flow.SharingStarted.Lazily, null)
 
     private val client = OkHttpClient()
+
+    fun registrarBotonPanico() {
+        viewModelScope.launch {
+            try {
+                val existing = prefs.uuidBoton.first()
+                if (!existing.isNullOrBlank()) {
+                    Log.d("DronGuard", "UUID ya almacenado: $existing")
+                    return@launch
+                }
+
+                val bodyJson = JSONObject().apply {
+                    put("nombre", "javier")
+                    put("apellido_paterno", "fernandez")
+                    put("apellido_materno", "ayala")
+                    put("direccion", "av. revolucion 439")
+                    put("calle", "av. revolucion 439")
+                    put("colonia", "San Pedro de los Pinos")
+                    put("municipio", "Benito Juarez")
+                    put("estado", "CDMX")
+                    put("cp", "03800")
+                    put("celular", "5535033739")
+                    put("correo", "fjfayala@gmail.com")
+                    put("contacto_1", "franciso fernandez")
+                    put("telefono_1", "5512345678")
+                    put("contacto_2", "roverto ayala")
+                    put("telefono_2", "5587654321")
+                }
+
+                val body = bodyJson.toString().toRequestBody("application/json".toMediaType())
+                val request = Request.Builder()
+                    .url(com.example.bitacoradigital.util.Constants.DRON_GUARD_REGISTRO)
+                    .post(body)
+                    .addHeader("X-Authorization", com.example.bitacoradigital.util.Constants.DRON_GUARD_TOKEN)
+                    .addHeader("Content-Type", "application/json")
+                    .build()
+
+                val response = withContext(Dispatchers.IO) { client.newCall(request).execute() }
+                val respBody = response.body?.string()
+                if (response.isSuccessful) {
+                    val uuid = JSONObject(respBody ?: "{}").optString("uuid_usuario")
+                    if (uuid.isNotEmpty()) {
+                        prefs.guardarUuidBoton(uuid)
+                        Log.d("DronGuard", "Registro exitoso uuid=$uuid")
+                    } else {
+                        Log.d("DronGuard", "Registro sin uuid: $respBody")
+                    }
+                } else {
+                    Log.e("DronGuard", "Fallo registro code=${'$'}{response.code} body=${'$'}respBody")
+                }
+                response.close()
+            } catch (e: Exception) {
+                Log.e("DronGuard", "Error registrando usuario", e)
+            }
+        }
+    }
 
     fun enviarAlerta(lat: Double, lng: Double) {
         viewModelScope.launch {

--- a/app/src/main/java/com/example/bitacoradigital/viewmodel/SessionViewModel.kt
+++ b/app/src/main/java/com/example/bitacoradigital/viewmodel/SessionViewModel.kt
@@ -11,8 +11,6 @@ import android.util.Log
 import com.example.bitacoradigital.model.User
 import com.example.bitacoradigital.network.RetrofitInstance
 import com.google.gson.Gson
-import okhttp3.OkHttpClient
-import okhttp3.Request
 import okhttp3.RequestBody.Companion.toRequestBody
 import okhttp3.MediaType.Companion.toMediaType
 import org.json.JSONObject
@@ -108,44 +106,6 @@ class SessionViewModel(application: Application) : AndroidViewModel(application)
         prefs.guardarSesion(token, user.id, user.persona_id, gson.toJson(user), user.Version)
     }
 
-    fun registrarBotonPanico() {
-        viewModelScope.launch {
-            try {
-                val bodyJson = JSONObject().apply {
-                    put("nombre", "javier")
-                    put("apellido_paterno", "fernandez")
-                    put("apellido_materno", "ayala")
-                    put("direccion", "av. revolucion 439")
-                    put("calle", "av. revolucion 439")
-                    put("colonia", "San Pedro de los Pinos")
-                    put("municipio", "Benito Juarez")
-                    put("estado", "CDMX")
-                    put("cp", "03800")
-                    put("celular", "5535033739")
-                    put("correo", "fjfayala@gmail.com")
-                    put("contacto_1", "franciso fernandez")
-                    put("telefono_1", "5512345678")
-                    put("contacto_2", "roverto ayala")
-                    put("telefono_2", "5587654321")
-                }
-                val body = bodyJson.toString().toRequestBody("application/json".toMediaType())
-                val request = Request.Builder()
-                    .url(com.example.bitacoradigital.util.Constants.DRON_GUARD_REGISTRO)
-                    .post(body)
-                    .addHeader("X-Authorization", com.example.bitacoradigital.util.Constants.DRON_GUARD_TOKEN)
-                    .addHeader("Content-Type", "application/json")
-                    .build()
-                val client = OkHttpClient()
-                val response = withContext(Dispatchers.IO) { client.newCall(request).execute() }
-                response.use { resp ->
-                    if (resp.isSuccessful) {
-                        val uuid = JSONObject(resp.body?.string() ?: "{}").optString("uuid_usuario")
-                        if (uuid.isNotEmpty()) prefs.guardarUuidBoton(uuid)
-                    }
-                }
-            } catch (_: Exception) { }
-        }
-    }
 
     fun setTemporalToken(token: String) {
         _token.value = token


### PR DESCRIPTION
## Summary
- move panic button registration logic into `DronGuardViewModel`
- trigger registration when `DronGuardScreen` is shown
- remove old registration calls from `SessionViewModel`

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68758cb9b678832fb0a005787e4a9e37