### PR TITLE
Fix new root comment creation

### DIFF
--- a/app/src/main/java/com/example/bitacoradigital/viewmodel/NovedadesViewModel.kt
+++ b/app/src/main/java/com/example/bitacoradigital/viewmodel/NovedadesViewModel.kt
@@ -97,10 +97,13 @@ class NovedadesViewModel(
             _cargando.value = true
             try {
                 val token = withContext(Dispatchers.IO) { prefs.sessionToken.firstOrNull() } ?: return@launch
-                val builder = MultipartBody.Builder().setType(MultipartBody.FORM)
+                val builder = MultipartBody.Builder()
+                    .setType(MultipartBody.FORM)
                     .addFormDataPart("contenido", contenido)
                     .addFormDataPart("perimetro", perimetroId.toString())
-                    .addFormDataPart("padre", padreId?.toString() ?: "null")
+                if (padreId != null) {
+                    builder.addFormDataPart("padre", padreId.toString())
+                }
                 if (imagenUri != null) {
                     val bytes = withContext(Dispatchers.IO) {
                         context.contentResolver.openInputStream(imagenUri)?.use { it.readBytes() }


### PR DESCRIPTION
## Summary
- avoid sending `padre` parameter when there is no parent comment so the backend accepts the request

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6877f3c8d7d4832f8004d815fd177e62