### PR TITLE
Add Bitácora General registration module

### DIFF
--- a/app/src/main/java/com/example/bitacoradigital/navigation/NavGraph.kt
+++ b/app/src/main/java/com/example/bitacoradigital/navigation/NavGraph.kt
@@ -151,6 +151,11 @@ fun AppNavGraph(
             RegistroVisitaWizardScreen(perimetroId = perimetroId, navController = navController)
         }
 
+        composable("bitacora/general") {
+            val perimetroId = homeViewModel.perimetroSeleccionado.value?.perimetroId ?: return@composable
+            RegistroBitacoraGeneralWizardScreen(perimetroId = perimetroId, navController = navController)
+        }
+
         composable("visitas/qr") {
             val perimetroId = homeViewModel.perimetroSeleccionado.value?.perimetroId ?: return@composable
             RegistroQRScreen(perimetroId = perimetroId, navController = navController)

--- a/app/src/main/java/com/example/bitacoradigital/ui/components/menu/ModuleButton.kt
+++ b/app/src/main/java/com/example/bitacoradigital/ui/components/menu/ModuleButton.kt
@@ -71,6 +71,7 @@ fun moduloIcon(nombre: String): ImageVector = when (nombre) {
     "Eventos" -> Icons.Default.Event
     "Administración de Usuarios" -> Icons.Default.Group
     "Registros de Visitas" -> Icons.Default.ListAlt
+    "Bitácora General" -> Icons.Default.ListAlt
     "Accesos" -> Icons.Default.DirectionsCar
     "DronGuard" -> Icons.Default.Warning
     else -> Icons.Default.Dashboard

--- a/app/src/main/java/com/example/bitacoradigital/ui/screens/HomeScreen.kt
+++ b/app/src/main/java/com/example/bitacoradigital/ui/screens/HomeScreen.kt
@@ -90,7 +90,7 @@ fun HomeScreen(
                 )
 
                 val perimetroMods = listOf("Dashboard", "Perímetro", "Residentes", "Accesos")
-                val accesoMods = listOf("Códigos QR", "Registros de Visitas")
+                val accesoMods = listOf("Códigos QR", "Registros de Visitas", "Bitácora General")
                 val guardiaMods = listOf("Guardia")
                 val novedadesMods = listOf("Novedades")
                 val dronGuardMods = listOf("DronGuard")
@@ -125,6 +125,7 @@ fun HomeScreen(
                                             "Dashboard" -> navController.navigate("dashboard")
                                             "Accesos" -> navController.navigate("accesos")
                                             "Residentes" -> navController.navigate("residentes")
+                                            "Bitácora General" -> navController.navigate("bitacora/general")
                                             else -> {}
                                         }
                                     }

--- a/app/src/main/java/com/example/bitacoradigital/ui/screens/RegistroBitacoraGeneralWizardScreen.kt
+++ b/app/src/main/java/com/example/bitacoradigital/ui/screens/RegistroBitacoraGeneralWizardScreen.kt
@@ -1,0 +1,61 @@
+package com.example.bitacoradigital.ui.screens
+
+import androidx.compose.runtime.*
+import androidx.compose.material3.*
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.viewmodel.compose.viewModel
+import androidx.compose.ui.platform.LocalContext
+import com.example.bitacoradigital.viewmodel.RegistroVisitaViewModel
+import com.example.bitacoradigital.viewmodel.RegistroVisitaViewModelFactory
+import com.example.bitacoradigital.ui.components.Stepper
+import com.example.bitacoradigital.ui.components.HomeConfigNavBar
+import com.example.bitacoradigital.network.ApiService
+import com.example.bitacoradigital.data.SessionPreferences
+import com.example.bitacoradigital.ui.screens.registrovisita.*
+import androidx.navigation.NavHostController
+
+@Composable
+fun RegistroBitacoraGeneralWizardScreen(perimetroId: Int, navController: NavHostController) {
+    val context = LocalContext.current
+    val apiService = remember { ApiService.create() }
+    val sessionPrefs = remember { SessionPreferences(context) }
+
+    val viewModel: RegistroVisitaViewModel = viewModel(
+        factory = RegistroVisitaViewModelFactory(apiService, sessionPrefs, perimetroId)
+    )
+
+    val pasoActual by viewModel.pasoActual.collectAsState()
+
+    Scaffold(
+        bottomBar = {
+            HomeConfigNavBar(
+                current = "",
+                onHomeClick = { navController.navigate("home") },
+                onConfigClick = { navController.navigate("configuracion") }
+            )
+        }
+    ) { innerPadding ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(innerPadding)
+                .padding(16.dp)
+        ) {
+            Stepper(pasoActual, totalPasos = 7)
+            Spacer(Modifier.height(24.dp))
+
+            when (pasoActual) {
+                1 -> PasoTelefono(viewModel)
+                2 -> PasoDocumento(viewModel)
+                3 -> PasoVerificacion(viewModel)
+                4 -> PasoDestinoGeneral(viewModel)
+                5 -> PasoFotos(viewModel)
+                6 -> PasoConfirmacionGeneral(viewModel)
+                7 -> PasoFinal(viewModel, navController)
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/example/bitacoradigital/ui/screens/VisitasScreen.kt
+++ b/app/src/main/java/com/example/bitacoradigital/ui/screens/VisitasScreen.kt
@@ -9,6 +9,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.PersonAdd
 import androidx.compose.material.icons.filled.QrCodeScanner
 import androidx.compose.material.icons.filled.QrCode
+import androidx.compose.material.icons.filled.ListAlt
 import androidx.compose.material3.*
 import androidx.compose.animation.animateContentSize
 import androidx.compose.runtime.Composable
@@ -66,6 +67,16 @@ fun VisitasScreen(
                 descripcion = "Escanea códigos QR de acceso rápido con verificación automática.",
                 color = MaterialTheme.colorScheme.primary,
                 onClick = { navController.navigate("visitas/qr") }
+            )
+        }
+
+        if ("bitacora general" in permisos) {
+            PermisoCard(
+                icon = Icons.Default.ListAlt,
+                titulo = "Bitácora General",
+                descripcion = "Registra entradas de bitácora general.",
+                color = MaterialTheme.colorScheme.primary,
+                onClick = { navController.navigate("bitacora/general") }
             )
         }
 

--- a/app/src/main/java/com/example/bitacoradigital/ui/screens/registrovisita/PasoConfirmacionGeneral.kt
+++ b/app/src/main/java/com/example/bitacoradigital/ui/screens/registrovisita/PasoConfirmacionGeneral.kt
@@ -1,0 +1,115 @@
+package com.example.bitacoradigital.ui.screens.registrovisita
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.unit.dp
+import coil.compose.AsyncImage
+import com.example.bitacoradigital.viewmodel.RegistroVisitaViewModel
+import androidx.compose.ui.platform.LocalContext
+
+@Composable
+fun PasoConfirmacionGeneral(viewModel: RegistroVisitaViewModel) {
+    val telefono by viewModel.telefono.collectAsState()
+    val nombre by viewModel.nombre.collectAsState()
+    val paterno by viewModel.apellidoPaterno.collectAsState()
+    val materno by viewModel.apellidoMaterno.collectAsState()
+    val documento = viewModel.documentoUri.value
+    val destino by viewModel.destinoSeleccionado.collectAsState()
+    val destinoGeneral by viewModel.destinoGeneral.collectAsState()
+    val fotos by viewModel.fotosAdicionales.collectAsState()
+    val cargandoReg by viewModel.cargandoRegistro.collectAsState()
+    val registroCompleto by viewModel.registroCompleto.collectAsState()
+    val context = LocalContext.current
+    val scrollState = rememberScrollState()
+
+    LaunchedEffect(registroCompleto) {
+        if (registroCompleto) viewModel.avanzarPaso()
+    }
+
+    Box(Modifier.fillMaxSize()) {
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(16.dp)
+                .verticalScroll(scrollState)
+        ) {
+            Text("Paso 6: Confirma tu Registro", style = MaterialTheme.typography.titleLarge)
+            Spacer(Modifier.height(16.dp))
+
+            Card(modifier = Modifier.fillMaxWidth()) {
+                Column(modifier = Modifier.padding(16.dp)) {
+                    Text("📱 Teléfono: $telefono")
+                    Text("👤 Nombre: $nombre $paterno $materno")
+                    destino?.let {
+                        Spacer(Modifier.height(4.dp))
+                        Text("📍 Destino: ${it.nombre} (ID ${it.perimetro_id})")
+                    }
+                    if (destinoGeneral.isNotBlank()) {
+                        Spacer(Modifier.height(4.dp))
+                        Text("📝 Destino ingresado: $destinoGeneral")
+                    }
+                }
+            }
+
+            Spacer(Modifier.height(16.dp))
+
+            documento?.let {
+                Text("Documento Oficial:", style = MaterialTheme.typography.bodyMedium)
+                Spacer(Modifier.height(8.dp))
+                AsyncImage(
+                    model = it,
+                    contentDescription = "Documento",
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(200.dp)
+                        .clip(RoundedCornerShape(8.dp))
+                )
+            }
+
+            if (fotos.isNotEmpty()) {
+                Spacer(Modifier.height(16.dp))
+                Text("Fotos Adicionales:")
+                Spacer(Modifier.height(8.dp))
+                Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                    fotos.forEach { foto ->
+                        AsyncImage(
+                            model = foto,
+                            contentDescription = null,
+                            modifier = Modifier
+                                .size(80.dp)
+                                .clip(RoundedCornerShape(8.dp))
+                        )
+                    }
+                }
+            }
+
+            Spacer(Modifier.height(24.dp))
+
+            Button(
+                onClick = { viewModel.registrarBitacoraGeneral(context) },
+                modifier = Modifier.fillMaxWidth()
+            ) {
+                Text("Finalizar Registro")
+            }
+        }
+
+        if (cargandoReg) {
+            Box(
+                modifier = Modifier.fillMaxSize().background(MaterialTheme.colorScheme.background.copy(alpha = 0.5f)),
+                contentAlignment = Alignment.Center
+            ) {
+                CircularProgressIndicator()
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/example/bitacoradigital/ui/screens/registrovisita/PasoDestinoGeneral.kt
+++ b/app/src/main/java/com/example/bitacoradigital/ui/screens/registrovisita/PasoDestinoGeneral.kt
@@ -1,0 +1,73 @@
+package com.example.bitacoradigital.ui.screens.registrovisita
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.example.bitacoradigital.model.JerarquiaNodo
+import com.example.bitacoradigital.viewmodel.RegistroVisitaViewModel
+
+@Composable
+fun PasoDestinoGeneral(viewModel: RegistroVisitaViewModel) {
+    val ruta by viewModel.rutaDestino.collectAsState()
+    val seleccionActual by viewModel.destinoSeleccionado.collectAsState()
+    val cargando by viewModel.cargandoDestino.collectAsState()
+    val error by viewModel.errorDestino.collectAsState()
+    val destinoGeneral by viewModel.destinoGeneral.collectAsState()
+    val snackbarHostState = remember { SnackbarHostState() }
+    val scrollState = rememberScrollState()
+
+    LaunchedEffect(Unit) {
+        viewModel.cargarJerarquiaDestino()
+    }
+
+    Box(Modifier.fillMaxSize()) {
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(16.dp)
+                .verticalScroll(scrollState)
+        ) {
+            Text("Paso 4: Selección de Destino", style = MaterialTheme.typography.titleLarge)
+            Spacer(modifier = Modifier.height(16.dp))
+
+            if (cargando) {
+                CircularProgressIndicator()
+            } else if (error != null) {
+                LaunchedEffect(error) {
+                    snackbarHostState.showSnackbar(error ?: "")
+                    viewModel.clearDestinoError()
+                }
+            } else {
+                NavegacionJerarquia(
+                    ruta = ruta,
+                    onSeleccion = { viewModel.navegarHacia(it) },
+                    onConfirmar = { viewModel.destinoSeleccionado.value = it },
+                    onRetroceder = { viewModel.retrocederNivel() }
+                )
+
+                if (seleccionActual != null) {
+                    Spacer(Modifier.height(16.dp))
+                    OutlinedTextField(
+                        value = destinoGeneral,
+                        onValueChange = { viewModel.destinoGeneral.value = it },
+                        label = { Text("Ingrese Destino") },
+                        modifier = Modifier.fillMaxWidth()
+                    )
+                    Spacer(Modifier.height(24.dp))
+                    Button(
+                        onClick = { viewModel.avanzarPaso() },
+                        enabled = destinoGeneral.isNotBlank(),
+                        modifier = Modifier.fillMaxWidth()
+                    ) { Text("Siguiente") }
+                }
+            }
+        }
+        SnackbarHost(hostState = snackbarHostState, modifier = Modifier.align(Alignment.BottomCenter))
+    }
+}

--- a/app/src/main/java/com/example/bitacoradigital/viewmodel/RegistroVisitaViewModel.kt
+++ b/app/src/main/java/com/example/bitacoradigital/viewmodel/RegistroVisitaViewModel.kt
@@ -121,6 +121,7 @@ class RegistroVisitaViewModel(
         respuestaRegistro.value = null
         residentesDestino.value = emptyList()
         invitanteId.value = null
+        destinoGeneral.value = ""
     }
     val nivelesDestino = MutableStateFlow<List<NivelDestino>>(emptyList())
     val seleccionDestino = MutableStateFlow<Map<Int, OpcionDestino>>(emptyMap())
@@ -209,6 +210,7 @@ class RegistroVisitaViewModel(
     val cargandoResidentes = MutableStateFlow(false)
     val errorResidentes = MutableStateFlow<String?>(null)
     val invitanteId = MutableStateFlow<Int?>(null)
+    val destinoGeneral = MutableStateFlow("")
 
     fun agregarFoto(uri: Uri) {
         if (fotosAdicionales.value.size < 3) {
@@ -414,6 +416,68 @@ class RegistroVisitaViewModel(
 
                         respuestaRegistro.value = qrMsg ?: bodyStr
                         qrBitmap.value = qrImg
+                        registroCompleto.value = true
+                    } else {
+                        val errorBody = withContext(Dispatchers.IO) { resp.body?.string() }
+                        Log.e("RegistroVisita", "Error en el registro: $errorBody")
+                        _errorDestino.value = "Registro fallido: ${resp.code}"
+                    }
+                }
+
+            } catch (e: Exception) {
+                Log.e("RegistroVisita", "Excepción en el registro", e)
+                _errorDestino.value = "Error al registrar visita: ${e.localizedMessage}"
+            } finally {
+                _cargandoRegistro.value = false
+            }
+        }
+    }
+
+    fun registrarBitacoraGeneral(context: android.content.Context) {
+        viewModelScope.launch {
+            _cargandoRegistro.value = true
+            try {
+                val token = withContext(Dispatchers.IO) {
+                    sessionPrefs.sessionToken.first()
+                } ?: throw Exception("Token vacío")
+
+                val zonaId = destinoSeleccionado.value?.perimetro_id
+                    ?: throw Exception("Zona destino no seleccionada")
+
+                val dateFormat = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'", Locale.US).apply {
+                    timeZone = TimeZone.getTimeZone("UTC")
+                }
+                val fechaIso8601 = dateFormat.format(Date())
+
+                val json = org.json.JSONObject().apply {
+                    put("nombre", nombre.value)
+                    put("apellido_pat", apellidoPaterno.value)
+                    put("apellido_mat", apellidoMaterno.value)
+                    put("numero", telefono.value)
+                    put("id_perimetro", zonaId)
+                    put("fecha", fechaIso8601)
+                    put("general", destinoGeneral.value)
+                }
+
+                val mediaType = "application/json; charset=utf-8".toMediaType()
+                val body = json.toString().toRequestBody(mediaType)
+
+                val request = Request.Builder()
+                    .url("https://bit.cs3.mx/api/v1/registro-visita/")
+                    .post(body)
+                    .addHeader("x-session-token", token)
+                    .addHeader("Content-Type", "application/json")
+                    .build()
+
+                val client = OkHttpClient()
+                val response = withContext(Dispatchers.IO) {
+                    client.newCall(request).execute()
+                }
+
+                response.use { resp ->
+                    if (resp.isSuccessful) {
+                        val bodyStr = withContext(Dispatchers.IO) { resp.body?.string() }
+                        respuestaRegistro.value = bodyStr
                         registroCompleto.value = true
                     } else {
                         val errorBody = withContext(Dispatchers.IO) { resp.body?.string() }


### PR DESCRIPTION
## Summary
- implement `RegistroBitacoraGeneralWizardScreen` and new steps
- allow entering a text destination and posting it with `general` field
- show "Bitácora General" option in Visitas screen when permission is present
- route `bitacora/general` in navigation
- add icon mapping and module support in Home screen
- extend `RegistroVisitaViewModel` with `destinoGeneral` and registration logic

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_688bca6100bc832faae3534cd26d6c17