### PR TITLE
feat: add handheld scanning module

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -82,6 +82,7 @@ dependencies {
     implementation("com.google.mlkit:barcode-scanning:17.2.0")
     implementation("com.google.android.gms:play-services-location:21.0.1")
     implementation("com.google.android.gms:play-services-location:21.3.0")
+    implementation("androidx.localbroadcastmanager:localbroadcastmanager:1.1.0")
     testImplementation("junit:junit:4.13.2")
     androidTestImplementation("androidx.test.ext:junit:1.2.1")
     androidTestImplementation("androidx.test.espresso:espresso-core:3.6.1")

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -39,6 +39,14 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+
+        <receiver
+            android:name=".scanner.DataWedgeReceiver"
+            android:exported="false">
+            <intent-filter>
+                <action android:name="com.symbol.datawedge.data" />
+            </intent-filter>
+        </receiver>
     </application>
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.CAMERA" />

--- a/app/src/main/java/com/example/bitacoradigital/navigation/NavGraph.kt
+++ b/app/src/main/java/com/example/bitacoradigital/navigation/NavGraph.kt
@@ -27,6 +27,7 @@ import com.example.bitacoradigital.ui.screens.perimetro.PerimetrosScreen
 import com.example.bitacoradigital.ui.screens.qr.CodigosQRScreen
 import com.example.bitacoradigital.ui.screens.qr.GenerarCodigoQRScreen
 import com.example.bitacoradigital.ui.screens.qr.SeguimientoQRScreen
+import com.example.bitacoradigital.ui.screens.handheld.EscaneoHandheldScreen
 import com.example.bitacoradigital.ui.screens.dashboard.DashboardScreen
 import com.example.bitacoradigital.ui.screens.accesos.AccesosScreen
 import com.example.bitacoradigital.ui.screens.residentes.ResidentesScreen
@@ -168,6 +169,10 @@ fun AppNavGraph(
 
         composable("lomascountry/qr") {
             RegistroQRScreen(perimetroId = 4158, navController = navController)
+        }
+
+        composable("lomascountry/handheld") {
+            EscaneoHandheldScreen(perimetroId = 4158, navController = navController)
         }
 
 

--- a/app/src/main/java/com/example/bitacoradigital/repository/CheckpointRepository.kt
+++ b/app/src/main/java/com/example/bitacoradigital/repository/CheckpointRepository.kt
@@ -1,0 +1,51 @@
+package com.example.bitacoradigital.repository
+
+import android.util.Log
+import com.example.bitacoradigital.model.Checkpoint
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import org.json.JSONArray
+import java.util.concurrent.TimeUnit
+
+class CheckpointRepository {
+    companion object {
+        private const val TAG = "CheckpointRepo"
+    }
+
+    private val client = OkHttpClient.Builder()
+        .connectTimeout(5, TimeUnit.SECONDS)
+        .readTimeout(5, TimeUnit.SECONDS)
+        .build()
+
+    suspend fun getCheckpoints(perimetroId: Int, token: String): List<Checkpoint> {
+        val request = Request.Builder()
+            .url("https://bit.cs3.mx/api/v1/checkpoints/?perimetro=$perimetroId")
+            .get()
+            .addHeader("x-session-token", token)
+            .build()
+
+        val response = client.newCall(request).execute()
+        response.use { resp ->
+            if (!resp.isSuccessful) {
+                Log.d(TAG, "Error ${'$'}{resp.code} al cargar checkpoints")
+                return emptyList()
+            }
+            val jsonStr = resp.body?.string() ?: "[]"
+            val arr = JSONArray(jsonStr)
+            val list = mutableListOf<Checkpoint>()
+            for (i in 0 until arr.length()) {
+                val obj = arr.getJSONObject(i)
+                list.add(
+                    Checkpoint(
+                        checkpoint_id = obj.optInt("checkpoint_id"),
+                        nombre = obj.optString("nombre"),
+                        tipo = obj.optString("tipo"),
+                        perimetro = obj.optInt("perimetro")
+                    )
+                )
+            }
+            return list
+        }
+    }
+}
+

--- a/app/src/main/java/com/example/bitacoradigital/scanner/DataWedgeReceiver.kt
+++ b/app/src/main/java/com/example/bitacoradigital/scanner/DataWedgeReceiver.kt
@@ -1,0 +1,15 @@
+package com.example.bitacoradigital.scanner
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import androidx.localbroadcastmanager.content.LocalBroadcastManager
+
+class DataWedgeReceiver : BroadcastReceiver() {
+    override fun onReceive(context: Context, intent: Intent) {
+        val data = intent.getStringExtra("com.symbol.datawedge.data_string") ?: return
+        val local = Intent("scanner-data").apply { putExtra("data", data) }
+        LocalBroadcastManager.getInstance(context).sendBroadcast(local)
+    }
+}
+

--- a/app/src/main/java/com/example/bitacoradigital/ui/screens/LomasCountryScreen.kt
+++ b/app/src/main/java/com/example/bitacoradigital/ui/screens/LomasCountryScreen.kt
@@ -11,6 +11,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavHostController
 import com.example.bitacoradigital.ui.components.HomeConfigNavBar
+import com.example.bitacoradigital.util.FeatureGate
 
 @Composable
 fun LomasCountryScreen(
@@ -55,6 +56,16 @@ fun LomasCountryScreen(
                     color = MaterialTheme.colorScheme.primary,
                     onClick = { navController.navigate("lomascountry/qr") }
                 )
+
+                if (FeatureGate.hasPermission("Escaneo con Handheld", permisos)) {
+                    PermisoCard(
+                        icon = Icons.Default.QrCodeScanner,
+                        titulo = "Escaneo con Handheld",
+                        descripcion = "Lectura de códigos con lector físico Zebra.",
+                        color = MaterialTheme.colorScheme.primary,
+                        onClick = { navController.navigate("lomascountry/handheld") }
+                    )
+                }
 
                 PermisoCard(
                     icon = Icons.Default.QrCode,

--- a/app/src/main/java/com/example/bitacoradigital/ui/screens/handheld/EscaneoHandheldScreen.kt
+++ b/app/src/main/java/com/example/bitacoradigital/ui/screens/handheld/EscaneoHandheldScreen.kt
@@ -1,0 +1,134 @@
+package com.example.bitacoradigital.ui.screens.handheld
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalLifecycleOwner
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
+import androidx.lifecycle.viewmodel.compose.viewModel
+import androidx.navigation.NavHostController
+import com.example.bitacoradigital.data.SessionPreferences
+import com.example.bitacoradigital.model.Checkpoint
+import com.example.bitacoradigital.ui.components.HomeConfigNavBar
+import com.example.bitacoradigital.viewmodel.EscaneoHandheldViewModel
+import com.example.bitacoradigital.viewmodel.EscaneoHandheldViewModelFactory
+
+@Composable
+fun EscaneoHandheldScreen(perimetroId: Int, navController: NavHostController) {
+    val context = LocalContext.current
+    val prefs = remember { SessionPreferences(context) }
+    val viewModel: EscaneoHandheldViewModel = viewModel(factory = EscaneoHandheldViewModelFactory(prefs, perimetroId))
+
+    val checkpoints by viewModel.checkpoints.collectAsState()
+    val seleccionado by viewModel.seleccionado.collectAsState()
+    val cargando by viewModel.cargando.collectAsState()
+    val resultado by viewModel.resultado.collectAsState()
+    val scannedText by viewModel.scannedText.collectAsState()
+    val networkError by viewModel.networkError.collectAsState()
+
+    LaunchedEffect(Unit) { viewModel.cargarCheckpoints() }
+    LaunchedEffect(checkpoints) {
+        if (checkpoints.size == 1) viewModel.seleccionado.value = checkpoints.first()
+    }
+
+    LaunchedEffect(scannedText) {
+        scannedText?.let {
+            viewModel.procesarCodigo(it)
+            viewModel.scannedText.value = null
+        }
+    }
+
+    Scaffold(
+        bottomBar = {
+            HomeConfigNavBar(
+                current = "",
+                onHomeClick = { navController.navigate("home") },
+                onConfigClick = { navController.navigate("configuracion") }
+            )
+        }
+    ) { innerPadding ->
+        Box(modifier = Modifier.fillMaxSize().padding(innerPadding)) {
+            when {
+                seleccionado == null -> CheckpointList(checkpoints) { viewModel.seleccionado.value = it }
+                cargando -> LoadingView()
+                resultado != null -> ResultadoView(resultado!!){
+                    navController.navigate("lomascountry") { popUpTo("lomascountry") { inclusive = true } }
+                }
+                else -> ScanView(viewModel)
+            }
+            if (networkError) {
+                Text(
+                    text = "Error de red",
+                    modifier = Modifier.align(Alignment.BottomCenter).padding(16.dp),
+                    color = MaterialTheme.colorScheme.error
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun CheckpointList(checkpoints: List<Checkpoint>, onSelect: (Checkpoint) -> Unit) {
+    LazyColumn(modifier = Modifier.fillMaxSize(), contentPadding = PaddingValues(16.dp)) {
+        items(checkpoints) { cp ->
+            Card(modifier = Modifier.fillMaxWidth().padding(vertical = 8.dp).clickable { onSelect(cp) }) {
+                Text(cp.nombre, modifier = Modifier.padding(24.dp), fontWeight = FontWeight.SemiBold)
+            }
+        }
+    }
+}
+
+@Composable
+private fun ScanView(viewModel: EscaneoHandheldViewModel) {
+    val context = LocalContext.current
+    val lifecycle = LocalLifecycleOwner.current.lifecycle
+    DisposableEffect(lifecycle) {
+        val observer = LifecycleEventObserver { _, event ->
+            when (event) {
+                Lifecycle.Event.ON_RESUME -> viewModel.startScanner(context)
+                Lifecycle.Event.ON_PAUSE -> viewModel.stopScanner(context)
+                else -> {}
+            }
+        }
+        lifecycle.addObserver(observer)
+        onDispose {
+            lifecycle.removeObserver(observer)
+            viewModel.stopScanner(context)
+        }
+    }
+    Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+        Text("Usa los botones físicos para escanear", textAlign = TextAlign.Center)
+    }
+}
+
+@Composable
+private fun LoadingView() {
+    Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+        CircularProgressIndicator()
+    }
+}
+
+@Composable
+private fun ResultadoView(resultado: String, onFinish: () -> Unit) {
+    Column(
+        modifier = Modifier.fillMaxSize(),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center
+    ) {
+        Text("Resultado: $resultado", fontWeight = FontWeight.Bold)
+        Spacer(modifier = Modifier.height(16.dp))
+        Button(onClick = onFinish) { Text("Finalizar") }
+    }
+}
+

--- a/app/src/main/java/com/example/bitacoradigital/util/FeatureGate.kt
+++ b/app/src/main/java/com/example/bitacoradigital/util/FeatureGate.kt
@@ -1,0 +1,8 @@
+package com.example.bitacoradigital.util
+
+object FeatureGate {
+    fun hasPermission(permission: String, permisos: List<String>): Boolean {
+        return permisos.contains(permission)
+    }
+}
+

--- a/app/src/main/java/com/example/bitacoradigital/viewmodel/EscaneoHandheldViewModel.kt
+++ b/app/src/main/java/com/example/bitacoradigital/viewmodel/EscaneoHandheldViewModel.kt
@@ -1,0 +1,145 @@
+package com.example.bitacoradigital.viewmodel
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.content.IntentFilter
+import android.util.Log
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.viewModelScope
+import androidx.localbroadcastmanager.content.LocalBroadcastManager
+import com.example.bitacoradigital.data.SessionPreferences
+import com.example.bitacoradigital.model.Checkpoint
+import com.example.bitacoradigital.repository.CheckpointRepository
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.RequestBody.Companion.toRequestBody
+import org.json.JSONObject
+import java.util.concurrent.TimeUnit
+
+class EscaneoHandheldViewModel(
+    private val prefs: SessionPreferences,
+    private val perimetroId: Int,
+    private val repo: CheckpointRepository = CheckpointRepository()
+) : ViewModel() {
+
+    companion object {
+        private const val TAG = "EscaneoHandheld"
+    }
+
+    private val _checkpoints = MutableStateFlow<List<Checkpoint>>(emptyList())
+    val checkpoints: StateFlow<List<Checkpoint>> = _checkpoints.asStateFlow()
+
+    val seleccionado = MutableStateFlow<Checkpoint?>(null)
+    val scannedText = MutableStateFlow<String?>(null)
+
+    private val _cargando = MutableStateFlow(false)
+    val cargando: StateFlow<Boolean> = _cargando.asStateFlow()
+
+    private val _resultado = MutableStateFlow<String?>(null)
+    val resultado: StateFlow<String?> = _resultado.asStateFlow()
+
+    val networkError = MutableStateFlow(false)
+
+    private val scannerReceiver = object : BroadcastReceiver() {
+        override fun onReceive(context: Context?, intent: Intent?) {
+            val data = intent?.getStringExtra("data")
+            if (!data.isNullOrBlank()) {
+                Log.d(TAG, "Scan recibido: $data")
+                scannedText.value = data
+            }
+        }
+    }
+
+    fun startScanner(context: Context) {
+        LocalBroadcastManager.getInstance(context)
+            .registerReceiver(scannerReceiver, IntentFilter("scanner-data"))
+    }
+
+    fun stopScanner(context: Context) {
+        LocalBroadcastManager.getInstance(context).unregisterReceiver(scannerReceiver)
+    }
+
+    fun cargarCheckpoints() {
+        viewModelScope.launch {
+            _cargando.value = true
+            networkError.value = false
+            try {
+                val token = withContext(Dispatchers.IO) { prefs.sessionToken.first() } ?: return@launch
+                Log.d(TAG, "Cargando checkpoints para perimetro $perimetroId")
+                val list = withContext(Dispatchers.IO) { repo.getCheckpoints(perimetroId, token) }
+                _checkpoints.value = list
+            } catch (e: Exception) {
+                Log.d(TAG, "Error cargando checkpoints", e)
+                networkError.value = true
+            } finally {
+                _cargando.value = false
+            }
+        }
+    }
+
+    fun procesarCodigo(codigo: String) {
+        val checkpoint = seleccionado.value ?: return
+        viewModelScope.launch {
+            _cargando.value = true
+            networkError.value = false
+            try {
+                val json = JSONObject().apply {
+                    put("codigo", codigo)
+                    put("checkpoint", checkpoint.checkpoint_id)
+                }
+                val body = json.toString().toRequestBody("application/json".toMediaType())
+                val client = OkHttpClient.Builder()
+                    .connectTimeout(5, TimeUnit.SECONDS)
+                    .readTimeout(5, TimeUnit.SECONDS)
+                    .build()
+                val request = Request.Builder()
+                    .url("http://qr.cs3.mx/bite/leer-qr")
+                    .post(body)
+                    .addHeader("Content-Type", "application/json")
+                    .build()
+                val response = withContext(Dispatchers.IO) { client.newCall(request).execute() }
+                response.use { resp ->
+                    if (resp.isSuccessful) {
+                        val resStr = withContext(Dispatchers.IO) { resp.body?.string() }
+                        Log.d(TAG, "Respuesta exitosa: $resStr")
+                        val obj = JSONObject(resStr ?: "{}")
+                        val estado = obj.optString("estado", null)
+                        _resultado.value = estado ?: obj.optString("error", "error")
+                    } else {
+                        Log.d(TAG, "Error ${'$'}{resp.code}")
+                        _resultado.value = "error"
+                    }
+                }
+            } catch (e: Exception) {
+                Log.d(TAG, "Excepcion procesando codigo", e)
+                networkError.value = true
+            } finally {
+                _cargando.value = false
+            }
+        }
+    }
+}
+
+class EscaneoHandheldViewModelFactory(
+    private val prefs: SessionPreferences,
+    private val perimetroId: Int
+) : ViewModelProvider.Factory {
+    override fun <T : ViewModel> create(modelClass: Class<T>): T {
+        if (modelClass.isAssignableFrom(EscaneoHandheldViewModel::class.java)) {
+            @Suppress("UNCHECKED_CAST")
+            return EscaneoHandheldViewModel(prefs, perimetroId) as T
+        }
+        throw IllegalArgumentException("Unknown ViewModel class")
+    }
+}
+


### PR DESCRIPTION
## Summary
- add feature gate and permission card for "Escaneo con Handheld"
- integrate Zebra DataWedge broadcast receiver and handheld scanning screen
- wire up navigation and repository for checkpoint lookups

## Testing
- `./gradlew build` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68951cd5c7cc832fa5a3a97a645d0646