### PR TITLE
feat: soporte de rutas locales para leer qr

### DIFF
--- a/app/src/main/java/com/example/bitacoradigital/ui/screens/handheld/EscaneoHandheldScreen.kt
+++ b/app/src/main/java/com/example/bitacoradigital/ui/screens/handheld/EscaneoHandheldScreen.kt
@@ -102,9 +102,9 @@ fun EscaneoHandheldScreen(perimetroId: Int, navController: NavHostController) {
                     text = res
                 )
             }
-            if (networkError) {
+            networkError?.let { err ->
                 Text(
-                    text = "Error de red",
+                    text = err,
                     modifier = Modifier.align(Alignment.BottomCenter).padding(16.dp),
                     color = MaterialTheme.colorScheme.error
                 )


### PR DESCRIPTION
## Summary
- intentar leer códigos QR usando el endpoint interno principal 192.168.2.200 y enviar `x-session-token`
- usar 192.168.9.200 como respaldo en caso de fallo
- mostrar un mensaje de red interna cuando no hay conexión a ninguna ruta

## Testing
- `./gradlew test` *(falla: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_689ce766398c832fb25d1fa8eab5dd0d