### PR TITLE
Add location permissions required for DronGuard alerts

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -57,6 +57,8 @@
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.CAMERA" />
     <uses-permission android:name="com.symbol.datawedge.permission.BROADCAST" />
+    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
+    <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
 
 
 </manifest>


### PR DESCRIPTION
## Summary
- declare fine and coarse location permissions in the Android manifest so the DronGuard alert flow can obtain runtime grants

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e1533faed8832faf496e513cf070ae