### PR TITLE
Fix KeyboardOptions import in LomasCountryRegistroScreen

### DIFF
--- a/app/src/main/java/com/example/bitacoradigital/ui/screens/lomascountry/LomasCountryRegistroScreen.kt
+++ b/app/src/main/java/com/example/bitacoradigital/ui/screens/lomascountry/LomasCountryRegistroScreen.kt
@@ -50,7 +50,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.text.input.KeyboardOptions
+import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp


### PR DESCRIPTION
## Summary
- fix the import for `KeyboardOptions` in the Lomas Country registration screen to use the foundation package

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_6908d2abbf78832fb796297933030418