### PR TITLE
Add detailed logging for QR endpoint selection

### DIFF
--- a/app/src/main/java/com/example/bitacoradigital/viewmodel/RegistroVisitaViewModel.kt
+++ b/app/src/main/java/com/example/bitacoradigital/viewmodel/RegistroVisitaViewModel.kt
@@ -657,8 +657,16 @@ open class RegistroVisitaViewModel(
                                             bytes.toRequestBody("image/jpeg".toMediaTypeOrNull())
                                         ).build()
                                     val qrEndpoint = if (telefonoSeleccionDesdeLista.value) {
+                                        Log.d(
+                                            "RegistroVisita",
+                                            "Enviando solicitud de QR desde el endpoint enviar-qr-id-ws"
+                                        )
                                         "http://qr.cs3.mx/bite/enviar-qr-id-ws/"
                                     } else {
+                                        Log.d(
+                                            "RegistroVisita",
+                                            "Enviando solicitud de QR desde el endpoint enviar-qr-id-mws"
+                                        )
                                         "http://qr.cs3.mx/bite/enviar-qr-id-mws/"
                                     }
                                     val qrRequest = Request.Builder()
@@ -672,8 +680,7 @@ open class RegistroVisitaViewModel(
                                         .callTimeout(0, TimeUnit.MILLISECONDS)
                                         .build()
                                     val qrResp = withContext(Dispatchers.IO) { qrClient.newCall(qrRequest).execute() }
-                                    Log.d("Que esta pasando", "Ayuda: algo mas")
-                                    Log.d("Que esta pasando", "Ayuda: $qrResp")
+                                    Log.d("RegistroVisita", "Respuesta del endpoint seleccionado: $qrResp")
 
                                     qrResp.use { qrR ->
                                         if (qrR.isSuccessful) {


### PR DESCRIPTION
## Summary
- add explicit debug logs indicating which QR endpoint is being used
- log the HTTP response received from the selected endpoint

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_6908db3b21d8832f98398d5ee25588d6