### PR TITLE
Restore original Lomas Country registration endpoint

### DIFF
--- a/app/src/main/java/com/example/bitacoradigital/viewmodel/lomascountry/LomasCountryRegistroViewModel.kt
+++ b/app/src/main/java/com/example/bitacoradigital/viewmodel/lomascountry/LomasCountryRegistroViewModel.kt
@@ -45,10 +45,6 @@ class LomasCountryRegistroViewModel(
         "http://192.168.8.100:3457/bite/registro/list"
     )
 
-    private val registroEndpoints = telefonosEndpoints.map { endpoint ->
-        endpoint.replace("/list", "/create")
-    }
-
     init {
         iniciarActualizacionTelefonos()
     }
@@ -108,10 +104,6 @@ class LomasCountryRegistroViewModel(
             }
         }
         null
-    }
-
-    override fun obtenerRegistroEndpoints(): List<String> {
-        return registroEndpoints + super.obtenerRegistroEndpoints()
     }
 
     fun prepararRegistroConTelefono(numero: String, desdeLista: Boolean) {


### PR DESCRIPTION
## Summary
- remove the fallback overrides for the Lomas Country registro/create endpoint so it matches the previous implementation

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_6908df3c67fc832fadf1478222aa9d26